### PR TITLE
Feature/25 remove validate event

### DIFF
--- a/docs/class-DSchoenbauer.Orm.CrudModel.html
+++ b/docs/class-DSchoenbauer.Orm.CrudModel.html
@@ -172,7 +172,7 @@
 
 				<b>Author:</b>
 				David Schoenbauer<br>
-			<b>Located at</b> <a href="source-class-DSchoenbauer.Orm.CrudModel.html#29-124" title="Go to source code">Orm/CrudModel.php</a>
+			<b>Located at</b> <a href="source-class-DSchoenbauer.Orm.CrudModel.html#29-102" title="Go to source code">Orm/CrudModel.php</a>
 		<br>
 	</div>
 
@@ -235,7 +235,7 @@
 
 		<td class="name"><div>
 		<a class="anchor" href="#_fetch">#</a>
-		<code><a href="source-class-DSchoenbauer.Orm.CrudModel.html#51-63" title="Go to source code">fetch</a>( <span>integer <var>$id</var></span> )</code>
+		<code><a href="source-class-DSchoenbauer.Orm.CrudModel.html#51-62" title="Go to source code">fetch</a>( <span>integer <var>$id</var></span> )</code>
 
 		<div class="description short">
 			<p>Process the return of a single record</p>
@@ -278,7 +278,7 @@
 
 		<td class="name"><div>
 		<a class="anchor" href="#_fetchAll">#</a>
-		<code><a href="source-class-DSchoenbauer.Orm.CrudModel.html#65-75" title="Go to source code">fetchAll</a>( )</code>
+		<code><a href="source-class-DSchoenbauer.Orm.CrudModel.html#64-73" title="Go to source code">fetchAll</a>( )</code>
 
 		<div class="description short">
 			<p>Process the return of a collection of data</p>
@@ -316,7 +316,7 @@
 
 		<td class="name"><div>
 		<a class="anchor" href="#_update">#</a>
-		<code><a href="source-class-DSchoenbauer.Orm.CrudModel.html#77-90" title="Go to source code">update</a>( <span>integer <var>$id</var></span>, <span>array <var>$data</var></span> )</code>
+		<code><a href="source-class-DSchoenbauer.Orm.CrudModel.html#75-88" title="Go to source code">update</a>( <span>integer <var>$id</var></span>, <span>array <var>$data</var></span> )</code>
 
 		<div class="description short">
 			<p>Process the update of data for a given id</p>
@@ -361,7 +361,7 @@
 
 		<td class="name"><div>
 		<a class="anchor" href="#_delete">#</a>
-		<code><a href="source-class-DSchoenbauer.Orm.CrudModel.html#92-104" title="Go to source code">delete</a>( <span>integer <var>$id</var></span> )</code>
+		<code><a href="source-class-DSchoenbauer.Orm.CrudModel.html#90-101" title="Go to source code">delete</a>( <span>integer <var>$id</var></span> )</code>
 
 		<div class="description short">
 			<p>Process the removal of a given record</p>
@@ -380,49 +380,6 @@
 				<h4>Returns</h4>
 				<div class="list">
 					boolean<br>returns true on success
-				</div>
-
-
-				<h4>Since</h4>
-				<div class="list">
-						v1.0.0<br>
-				</div>
-
-
-		</div>
-		</div></td>
-	</tr>
-	<tr data-order="processEvents" id="_processEvents">
-
-		<td class="attributes"><code>
-			 protected 
-
-			<code><a href="class-DSchoenbauer.Orm.CrudModel.html">DSchoenbauer\Orm\CrudModel</a></code>
-			
-			</code>
-		</td>
-
-		<td class="name"><div>
-		<a class="anchor" href="#_processEvents">#</a>
-		<code><a href="source-class-DSchoenbauer.Orm.CrudModel.html#106-123" title="Go to source code">processEvents</a>( <span>array <var>$events</var></span> )</code>
-
-		<div class="description short">
-			<p>Attaches given events into the event manager</p>
-		</div>
-
-		<div class="description detailed hidden">
-			<p>Attaches given events into the event manager</p>
-
-
-				<h4>Parameters</h4>
-				<div class="list"><dl>
-					<dt><var>$events</var></dt>
-					<dd></dd>
-				</dl></div>
-
-				<h4>Returns</h4>
-				<div class="list">
-					<code><a href="class-DSchoenbauer.Orm.CrudModel.html">DSchoenbauer\Orm\CrudModel</a></code>
 				</div>
 
 

--- a/docs/class-DSchoenbauer.Orm.Enum.ModelEvents.html
+++ b/docs/class-DSchoenbauer.Orm.Enum.ModelEvents.html
@@ -150,7 +150,7 @@
 
 				<b>Author:</b>
 				David Schoenbauer<br>
-			<b>Located at</b> <a href="source-class-DSchoenbauer.Orm.Enum.ModelEvents.html#27-64" title="Go to source code">Orm/Enum/ModelEvents.php</a>
+			<b>Located at</b> <a href="source-class-DSchoenbauer.Orm.Enum.ModelEvents.html#27-59" title="Go to source code">Orm/Enum/ModelEvents.php</a>
 		<br>
 	</div>
 
@@ -166,36 +166,12 @@
 
 	<table class="summary constants" id="constants">
 	<caption>Constants summary</caption>
-	<tr data-order="VALIDATE" id="VALIDATE">
-
-		<td class="attributes"><code>string</code></td>
-		<td class="name">
-			<code>
-				<a href="source-class-DSchoenbauer.Orm.Enum.ModelEvents.html#35-38" title="Go to source code"><b>VALIDATE</b></a>
-			</code>
-
-			<div class="description short">
-				<p>Called to validate data</p>
-			</div>
-
-			<div class="description detailed hidden">
-				<p>Called to validate data</p>
-
-			</div>
-		</td>
-		<td class="value">
-			<div>
-				<a href="#VALIDATE" class="anchor">#</a>
-				<code><span class="php-quote">'validate'</span></code>
-			</div>
-		</td>
-	</tr>
 	<tr data-order="CREATE" id="CREATE">
 
 		<td class="attributes"><code>string</code></td>
 		<td class="name">
 			<code>
-				<a href="source-class-DSchoenbauer.Orm.Enum.ModelEvents.html#40-43" title="Go to source code"><b>CREATE</b></a>
+				<a href="source-class-DSchoenbauer.Orm.Enum.ModelEvents.html#35-38" title="Go to source code"><b>CREATE</b></a>
 			</code>
 
 			<div class="description short">
@@ -219,7 +195,7 @@
 		<td class="attributes"><code>string</code></td>
 		<td class="name">
 			<code>
-				<a href="source-class-DSchoenbauer.Orm.Enum.ModelEvents.html#45-48" title="Go to source code"><b>FETCH</b></a>
+				<a href="source-class-DSchoenbauer.Orm.Enum.ModelEvents.html#40-43" title="Go to source code"><b>FETCH</b></a>
 			</code>
 
 			<div class="description short">
@@ -243,7 +219,7 @@
 		<td class="attributes"><code>string</code></td>
 		<td class="name">
 			<code>
-				<a href="source-class-DSchoenbauer.Orm.Enum.ModelEvents.html#50-53" title="Go to source code"><b>FETCH_ALL</b></a>
+				<a href="source-class-DSchoenbauer.Orm.Enum.ModelEvents.html#45-48" title="Go to source code"><b>FETCH_ALL</b></a>
 			</code>
 
 			<div class="description short">
@@ -267,7 +243,7 @@
 		<td class="attributes"><code>string</code></td>
 		<td class="name">
 			<code>
-				<a href="source-class-DSchoenbauer.Orm.Enum.ModelEvents.html#55-58" title="Go to source code"><b>UPDATE</b></a>
+				<a href="source-class-DSchoenbauer.Orm.Enum.ModelEvents.html#50-53" title="Go to source code"><b>UPDATE</b></a>
 			</code>
 
 			<div class="description short">
@@ -291,7 +267,7 @@
 		<td class="attributes"><code>string</code></td>
 		<td class="name">
 			<code>
-				<a href="source-class-DSchoenbauer.Orm.Enum.ModelEvents.html#60-63" title="Go to source code"><b>DELETE</b></a>
+				<a href="source-class-DSchoenbauer.Orm.Enum.ModelEvents.html#55-58" title="Go to source code"><b>DELETE</b></a>
 			</code>
 
 			<div class="description short">

--- a/docs/class-DSchoenbauer.Orm.Events.AbstractEvent.html
+++ b/docs/class-DSchoenbauer.Orm.Events.AbstractEvent.html
@@ -178,7 +178,7 @@
 
 				<b>Author:</b>
 				David Schoenbauer<br>
-			<b>Located at</b> <a href="source-class-DSchoenbauer.Orm.Events.AbstractEvent.html#31-76" title="Go to source code">Orm/Events/AbstractEvent.php</a>
+			<b>Located at</b> <a href="source-class-DSchoenbauer.Orm.Events.AbstractEvent.html#31-82" title="Go to source code">Orm/Events/AbstractEvent.php</a>
 		<br>
 	</div>
 
@@ -186,6 +186,36 @@
 
 	<table class="summary methods" id="methods">
 	<caption>Methods summary</caption>
+	<tr data-order="__construct" id="___construct">
+
+		<td class="attributes"><code>
+			 public 
+
+			
+			
+			</code>
+		</td>
+
+		<td class="name"><div>
+		<a class="anchor" href="#___construct">#</a>
+		<code><a href="source-class-DSchoenbauer.Orm.Events.AbstractEvent.html#41-44" title="Go to source code">__construct</a>( <span>array <var>$events</var> = []</span> )</code>
+
+		<div class="description short">
+			
+		</div>
+
+		<div class="description detailed hidden">
+			
+
+
+
+
+
+
+
+		</div>
+		</div></td>
+	</tr>
 	<tr data-order="visitModel" id="_visitModel">
 
 		<td class="attributes"><code>
@@ -198,7 +228,7 @@
 
 		<td class="name"><div>
 		<a class="anchor" href="#_visitModel">#</a>
-		<code><a href="source-class-DSchoenbauer.Orm.Events.AbstractEvent.html#41-51" title="Go to source code">visitModel</a>( <span><code><a href="class-DSchoenbauer.Orm.Model.html">DSchoenbauer\Orm\Model</a></code> <var>$model</var></span> )</code>
+		<code><a href="source-class-DSchoenbauer.Orm.Events.AbstractEvent.html#47-57" title="Go to source code">visitModel</a>( <span><code><a href="class-DSchoenbauer.Orm.Model.html">DSchoenbauer\Orm\Model</a></code> <var>$model</var></span> )</code>
 
 		<div class="description short">
 			<p>provides an opportunity to extend Model's functionality</p>
@@ -239,7 +269,7 @@
 
 		<td class="name"><div>
 		<a class="anchor" href="#_onExecute">#</a>
-		<code><a href="source-class-DSchoenbauer.Orm.Events.AbstractEvent.html#53" title="Go to source code">onExecute</a>( <span>Zend\EventManager\Event <var>$event</var></span> )</code>
+		<code><a href="source-class-DSchoenbauer.Orm.Events.AbstractEvent.html#59" title="Go to source code">onExecute</a>( <span>Zend\EventManager\Event <var>$event</var></span> )</code>
 
 		<div class="description short">
 			
@@ -269,7 +299,7 @@
 
 		<td class="name"><div>
 		<a class="anchor" href="#_getEvents">#</a>
-		<code><a href="source-class-DSchoenbauer.Orm.Events.AbstractEvent.html#55-63" title="Go to source code">getEvents</a>( )</code>
+		<code><a href="source-class-DSchoenbauer.Orm.Events.AbstractEvent.html#61-69" title="Go to source code">getEvents</a>( )</code>
 
 		<div class="description short">
 			<p>returns a list of event names that this object should be executed</p>
@@ -307,7 +337,7 @@
 
 		<td class="name"><div>
 		<a class="anchor" href="#_setEvents">#</a>
-		<code><a href="source-class-DSchoenbauer.Orm.Events.AbstractEvent.html#65-75" title="Go to source code">setEvents</a>( <span>array <var>$events</var></span> )</code>
+		<code><a href="source-class-DSchoenbauer.Orm.Events.AbstractEvent.html#71-81" title="Go to source code">setEvents</a>( <span>array <var>$events</var></span> )</code>
 
 		<div class="description short">
 			<p>defines a list of event names this object will listen for to execute</p>

--- a/docs/class-DSchoenbauer.Orm.Events.Persistence.PdoCreate.html
+++ b/docs/class-DSchoenbauer.Orm.Events.Persistence.PdoCreate.html
@@ -169,7 +169,7 @@
 
 				<b>Author:</b>
 				David Schoenbauer <a href="&#109;&#x61;&#105;&#108;&#x74;&#111;&#x3a;&#x64;&#115;&#x63;h&#111;&#x65;&#110;&#98;&#x61;&#117;&#x65;r&#64;&#x67;&#109;&#97;&#x69;&#108;&#x2e;&#x63;&#111;&#x6d;">&#x64;&#115;&#x63;h&#111;&#x65;&#110;&#98;&#x61;&#117;&#x65;r&#64;&#x67;&#109;&#97;&#x69;&#108;&#x2e;&#x63;&#111;&#x6d;</a><br>
-			<b>Located at</b> <a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoCreate.html#16-104" title="Go to source code">Orm/Events/Persistence/PdoCreate.php</a>
+			<b>Located at</b> <a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoCreate.html#16-106" title="Go to source code">Orm/Events/Persistence/PdoCreate.php</a>
 		<br>
 	</div>
 
@@ -189,7 +189,7 @@
 
 		<td class="name"><div>
 		<a class="anchor" href="#___construct">#</a>
-		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoCreate.html#27-37" title="Go to source code">__construct</a>( <span>PDO <var>$adapter</var></span>, <span>DSchoenbauer\Sql\Command\Create <var>$create</var> = <span class="php-keyword1">null</span></span> )</code>
+		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoCreate.html#27-39" title="Go to source code">__construct</a>( <span>array <var>$events</var></span>, <span>PDO <var>$adapter</var></span>, <span>DSchoenbauer\Sql\Command\Create <var>$create</var> = <span class="php-keyword1">null</span></span> )</code>
 
 		<div class="description short">
 			
@@ -201,6 +201,8 @@
 
 				<h4>Parameters</h4>
 				<div class="list"><dl>
+					<dt><var>$events</var></dt>
+					<dd>An array of event names to bind to</dd>
 					<dt><var>$adapter</var></dt>
 					<dd>PDO connection to a db of some sort.</dd>
 					<dt><var>$create</var></dt>
@@ -215,6 +217,8 @@ be lazy loaded for you</p></dd>
 						v1.0.0<br>
 				</div>
 
+				<h4>Overrides</h4>
+				<div class="list"><code><a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#___construct">DSchoenbauer\Orm\Events\AbstractEvent::__construct()</a></code></div>
 
 		</div>
 		</div></td>
@@ -231,7 +235,7 @@ be lazy loaded for you</p></dd>
 
 		<td class="name"><div>
 		<a class="anchor" href="#_onExecute">#</a>
-		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoCreate.html#39-57" title="Go to source code">onExecute</a>( <span>Zend\EventManager\Event <var>$event</var></span> )</code>
+		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoCreate.html#41-59" title="Go to source code">onExecute</a>( <span>Zend\EventManager\Event <var>$event</var></span> )</code>
 
 		<div class="description short">
 			<p>event action</p>
@@ -270,7 +274,7 @@ be lazy loaded for you</p></dd>
 
 		<td class="name"><div>
 		<a class="anchor" href="#_getAdapter">#</a>
-		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoCreate.html#59-67" title="Go to source code">getAdapter</a>( )</code>
+		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoCreate.html#61-69" title="Go to source code">getAdapter</a>( )</code>
 
 		<div class="description short">
 			<p>Returns a PHP Data Object</p>
@@ -308,7 +312,7 @@ be lazy loaded for you</p></dd>
 
 		<td class="name"><div>
 		<a class="anchor" href="#_setAdapter">#</a>
-		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoCreate.html#69-79" title="Go to source code">setAdapter</a>( <span>PDO <var>$adapter</var></span> )</code>
+		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoCreate.html#71-81" title="Go to source code">setAdapter</a>( <span>PDO <var>$adapter</var></span> )</code>
 
 		<div class="description short">
 			<p>PDO connection to a db of some sort.</p>
@@ -351,7 +355,7 @@ be lazy loaded for you</p></dd>
 
 		<td class="name"><div>
 		<a class="anchor" href="#_getCreate">#</a>
-		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoCreate.html#81-92" title="Go to source code">getCreate</a>( )</code>
+		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoCreate.html#83-94" title="Go to source code">getCreate</a>( )</code>
 
 		<div class="description short">
 			<p>object with logic for the Create. If Create is not provided one will be lazy loaded</p>
@@ -389,7 +393,7 @@ be lazy loaded for you</p></dd>
 
 		<td class="name"><div>
 		<a class="anchor" href="#_setCreate">#</a>
-		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoCreate.html#94-103" title="Go to source code">setCreate</a>( <span>DSchoenbauer\Sql\Command\Create <var>$create</var> = <span class="php-keyword1">null</span></span> )</code>
+		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoCreate.html#96-105" title="Go to source code">setCreate</a>( <span>DSchoenbauer\Sql\Command\Create <var>$create</var> = <span class="php-keyword1">null</span></span> )</code>
 
 		<div class="description short">
 			

--- a/docs/class-DSchoenbauer.Orm.Events.Persistence.PdoDelete.html
+++ b/docs/class-DSchoenbauer.Orm.Events.Persistence.PdoDelete.html
@@ -169,7 +169,7 @@
 
 				<b>Author:</b>
 				David Schoenbauer <a href="&#109;&#x61;&#105;&#108;&#x74;&#111;&#x3a;&#x64;&#115;&#x63;h&#111;&#x65;&#110;&#98;&#x61;&#117;&#x65;r&#64;&#x67;&#109;&#97;&#x69;&#108;&#x2e;&#x63;&#111;&#x6d;">&#x64;&#115;&#x63;h&#111;&#x65;&#110;&#98;&#x61;&#117;&#x65;r&#64;&#x67;&#109;&#97;&#x69;&#108;&#x2e;&#x63;&#111;&#x6d;</a><br>
-			<b>Located at</b> <a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoDelete.html#16-97" title="Go to source code">Orm/Events/Persistence/PdoDelete.php</a>
+			<b>Located at</b> <a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoDelete.html#16-103" title="Go to source code">Orm/Events/Persistence/PdoDelete.php</a>
 		<br>
 	</div>
 
@@ -189,7 +189,7 @@
 
 		<td class="name"><div>
 		<a class="anchor" href="#___construct">#</a>
-		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoDelete.html#27-30" title="Go to source code">__construct</a>( <span>PDO <var>$adapter</var></span>, <span>DSchoenbauer\Sql\Command\Delete <var>$delete</var> = <span class="php-keyword1">null</span></span> )</code>
+		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoDelete.html#27-36" title="Go to source code">__construct</a>( <span>array <var>$events</var></span>, <span>PDO <var>$adapter</var></span>, <span>DSchoenbauer\Sql\Command\Delete <var>$delete</var> = <span class="php-keyword1">null</span></span> )</code>
 
 		<div class="description short">
 			
@@ -199,10 +199,21 @@
 			
 
 
+				<h4>Parameters</h4>
+				<div class="list"><dl>
+					<dt><var>$events</var></dt>
+					<dd>An array of event names to bind to</dd>
+					<dt><var>$adapter</var></dt>
+					<dd></dd>
+					<dt><var>$delete</var></dt>
+					<dd></dd>
+				</dl></div>
 
 
 
 
+				<h4>Overrides</h4>
+				<div class="list"><code><a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#___construct">DSchoenbauer\Orm\Events\AbstractEvent::__construct()</a></code></div>
 
 		</div>
 		</div></td>
@@ -219,7 +230,7 @@
 
 		<td class="name"><div>
 		<a class="anchor" href="#_onExecute">#</a>
-		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoDelete.html#32-50" title="Go to source code">onExecute</a>( <span>Zend\EventManager\Event <var>$event</var></span> )</code>
+		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoDelete.html#38-56" title="Go to source code">onExecute</a>( <span>Zend\EventManager\Event <var>$event</var></span> )</code>
 
 		<div class="description short">
 			<p>event action</p>
@@ -258,7 +269,7 @@
 
 		<td class="name"><div>
 		<a class="anchor" href="#_getAdapter">#</a>
-		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoDelete.html#51-59" title="Go to source code">getAdapter</a>( )</code>
+		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoDelete.html#57-65" title="Go to source code">getAdapter</a>( )</code>
 
 		<div class="description short">
 			<p>Returns a PHP Data Object</p>
@@ -296,7 +307,7 @@
 
 		<td class="name"><div>
 		<a class="anchor" href="#_setAdapter">#</a>
-		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoDelete.html#61-71" title="Go to source code">setAdapter</a>( <span>PDO <var>$adapter</var></span> )</code>
+		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoDelete.html#67-77" title="Go to source code">setAdapter</a>( <span>PDO <var>$adapter</var></span> )</code>
 
 		<div class="description short">
 			<p>PDO connection to a db of some sort.</p>
@@ -339,7 +350,7 @@
 
 		<td class="name"><div>
 		<a class="anchor" href="#_getDelete">#</a>
-		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoDelete.html#73-84" title="Go to source code">getDelete</a>( )</code>
+		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoDelete.html#79-90" title="Go to source code">getDelete</a>( )</code>
 
 		<div class="description short">
 			<p>object with logic for the delete. If Delete is not provided one will be lazy loaded</p>
@@ -377,7 +388,7 @@
 
 		<td class="name"><div>
 		<a class="anchor" href="#_setDelete">#</a>
-		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoDelete.html#86-96" title="Go to source code">setDelete</a>( <span>DSchoenbauer\Sql\Command\Delete <var>$delete</var> = <span class="php-keyword1">null</span></span> )</code>
+		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoDelete.html#92-102" title="Go to source code">setDelete</a>( <span>DSchoenbauer\Sql\Command\Delete <var>$delete</var> = <span class="php-keyword1">null</span></span> )</code>
 
 		<div class="description short">
 			<p>Object that contains the delete logic</p>

--- a/docs/class-DSchoenbauer.Orm.Events.Persistence.PdoSelect.html
+++ b/docs/class-DSchoenbauer.Orm.Events.Persistence.PdoSelect.html
@@ -169,7 +169,7 @@
 
 				<b>Author:</b>
 				David Schoenbauer<br>
-			<b>Located at</b> <a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoSelect.html#35-122" title="Go to source code">Orm/Events/Persistence/PdoSelect.php</a>
+			<b>Located at</b> <a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoSelect.html#35-127" title="Go to source code">Orm/Events/Persistence/PdoSelect.php</a>
 		<br>
 	</div>
 
@@ -189,7 +189,7 @@
 
 		<td class="name"><div>
 		<a class="anchor" href="#___construct">#</a>
-		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoSelect.html#46-51" title="Go to source code">__construct</a>( <span>PDO <var>$adapter</var></span>, <span>DSchoenbauer\Sql\Command\Select <var>$select</var> = <span class="php-keyword1">null</span></span> )</code>
+		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoSelect.html#46-56" title="Go to source code">__construct</a>( <span>array <var>$events</var></span>, <span>PDO <var>$adapter</var></span>, <span>DSchoenbauer\Sql\Command\Select <var>$select</var> = <span class="php-keyword1">null</span></span> )</code>
 
 		<div class="description short">
 			
@@ -199,10 +199,21 @@
 			
 
 
+				<h4>Parameters</h4>
+				<div class="list"><dl>
+					<dt><var>$events</var></dt>
+					<dd>An array of event names to bind to</dd>
+					<dt><var>$adapter</var></dt>
+					<dd></dd>
+					<dt><var>$select</var></dt>
+					<dd></dd>
+				</dl></div>
 
 
 
 
+				<h4>Overrides</h4>
+				<div class="list"><code><a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#___construct">DSchoenbauer\Orm\Events\AbstractEvent::__construct()</a></code></div>
 
 		</div>
 		</div></td>
@@ -219,7 +230,7 @@
 
 		<td class="name"><div>
 		<a class="anchor" href="#_onExecute">#</a>
-		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoSelect.html#53-74" title="Go to source code">onExecute</a>( <span>Zend\EventManager\Event <var>$event</var></span> )</code>
+		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoSelect.html#58-79" title="Go to source code">onExecute</a>( <span>Zend\EventManager\Event <var>$event</var></span> )</code>
 
 		<div class="description short">
 			<p>event action</p>
@@ -258,7 +269,7 @@
 
 		<td class="name"><div>
 		<a class="anchor" href="#_getAdapter">#</a>
-		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoSelect.html#76-84" title="Go to source code">getAdapter</a>( )</code>
+		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoSelect.html#81-89" title="Go to source code">getAdapter</a>( )</code>
 
 		<div class="description short">
 			<p>Returns a PHP Data Object</p>
@@ -296,7 +307,7 @@
 
 		<td class="name"><div>
 		<a class="anchor" href="#_setAdapter">#</a>
-		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoSelect.html#86-96" title="Go to source code">setAdapter</a>( <span>PDO <var>$adapter</var></span> )</code>
+		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoSelect.html#91-101" title="Go to source code">setAdapter</a>( <span>PDO <var>$adapter</var></span> )</code>
 
 		<div class="description short">
 			<p>PDO connection to a db of some sort.</p>
@@ -339,7 +350,7 @@
 
 		<td class="name"><div>
 		<a class="anchor" href="#_getSelect">#</a>
-		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoSelect.html#98-109" title="Go to source code">getSelect</a>( )</code>
+		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoSelect.html#103-114" title="Go to source code">getSelect</a>( )</code>
 
 		<div class="description short">
 			<p>object with logic for the Select. If Select is not provided one will be lazy loaded</p>
@@ -377,7 +388,7 @@
 
 		<td class="name"><div>
 		<a class="anchor" href="#_setSelect">#</a>
-		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoSelect.html#111-121" title="Go to source code">setSelect</a>( <span>DSchoenbauer\Sql\Command\Select <var>$select</var> = <span class="php-keyword1">null</span></span> )</code>
+		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoSelect.html#116-126" title="Go to source code">setSelect</a>( <span>DSchoenbauer\Sql\Command\Select <var>$select</var> = <span class="php-keyword1">null</span></span> )</code>
 
 		<div class="description short">
 			<p>Object that contains the select logic</p>

--- a/docs/class-DSchoenbauer.Orm.Events.Persistence.PdoUpdate.html
+++ b/docs/class-DSchoenbauer.Orm.Events.Persistence.PdoUpdate.html
@@ -169,7 +169,7 @@
 
 				<b>Author:</b>
 				David Schoenbauer <a href="&#109;&#x61;&#105;&#108;&#x74;&#111;&#x3a;&#x64;&#115;&#x63;h&#111;&#x65;&#110;&#98;&#x61;&#117;&#x65;r&#64;&#x67;&#109;&#97;&#x69;&#108;&#x2e;&#x63;&#111;&#x6d;">&#x64;&#115;&#x63;h&#111;&#x65;&#110;&#98;&#x61;&#117;&#x65;r&#64;&#x67;&#109;&#97;&#x69;&#108;&#x2e;&#x63;&#111;&#x6d;</a><br>
-			<b>Located at</b> <a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoUpdate.html#16-98" title="Go to source code">Orm/Events/Persistence/PdoUpdate.php</a>
+			<b>Located at</b> <a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoUpdate.html#16-104" title="Go to source code">Orm/Events/Persistence/PdoUpdate.php</a>
 		<br>
 	</div>
 
@@ -189,7 +189,7 @@
 
 		<td class="name"><div>
 		<a class="anchor" href="#___construct">#</a>
-		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoUpdate.html#27-30" title="Go to source code">__construct</a>( <span>PDO <var>$adapter</var></span>, <span>DSchoenbauer\Sql\Command\Update <var>$update</var> = <span class="php-keyword1">null</span></span> )</code>
+		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoUpdate.html#27-36" title="Go to source code">__construct</a>( <span>array <var>$events</var></span>, <span>PDO <var>$adapter</var></span>, <span>DSchoenbauer\Sql\Command\Update <var>$update</var> = <span class="php-keyword1">null</span></span> )</code>
 
 		<div class="description short">
 			
@@ -199,10 +199,21 @@
 			
 
 
+				<h4>Parameters</h4>
+				<div class="list"><dl>
+					<dt><var>$events</var></dt>
+					<dd>An array of event names to bind to</dd>
+					<dt><var>$adapter</var></dt>
+					<dd></dd>
+					<dt><var>$update</var></dt>
+					<dd></dd>
+				</dl></div>
 
 
 
 
+				<h4>Overrides</h4>
+				<div class="list"><code><a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#___construct">DSchoenbauer\Orm\Events\AbstractEvent::__construct()</a></code></div>
 
 		</div>
 		</div></td>
@@ -219,7 +230,7 @@
 
 		<td class="name"><div>
 		<a class="anchor" href="#_onExecute">#</a>
-		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoUpdate.html#32-50" title="Go to source code">onExecute</a>( <span>Zend\EventManager\Event <var>$event</var></span> )</code>
+		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoUpdate.html#38-56" title="Go to source code">onExecute</a>( <span>Zend\EventManager\Event <var>$event</var></span> )</code>
 
 		<div class="description short">
 			<p>event action</p>
@@ -258,7 +269,7 @@
 
 		<td class="name"><div>
 		<a class="anchor" href="#_getAdapter">#</a>
-		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoUpdate.html#52-60" title="Go to source code">getAdapter</a>( )</code>
+		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoUpdate.html#58-66" title="Go to source code">getAdapter</a>( )</code>
 
 		<div class="description short">
 			<p>Returns a PHP Data Object</p>
@@ -296,7 +307,7 @@
 
 		<td class="name"><div>
 		<a class="anchor" href="#_setAdapter">#</a>
-		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoUpdate.html#62-72" title="Go to source code">setAdapter</a>( <span>PDO <var>$adapter</var></span> )</code>
+		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoUpdate.html#68-78" title="Go to source code">setAdapter</a>( <span>PDO <var>$adapter</var></span> )</code>
 
 		<div class="description short">
 			<p>PDO connection to a db of some sort.</p>
@@ -339,7 +350,7 @@
 
 		<td class="name"><div>
 		<a class="anchor" href="#_getUpdate">#</a>
-		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoUpdate.html#74-85" title="Go to source code">getUpdate</a>( )</code>
+		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoUpdate.html#80-91" title="Go to source code">getUpdate</a>( )</code>
 
 		<div class="description short">
 			<p>object with logic for the Update. If Update is not provided one will be lazy loaded</p>
@@ -377,7 +388,7 @@
 
 		<td class="name"><div>
 		<a class="anchor" href="#_setUpdate">#</a>
-		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoUpdate.html#87-97" title="Go to source code">setUpdate</a>( <span>DSchoenbauer\Sql\Command\Update <var>$update</var> = <span class="php-keyword1">null</span></span> )</code>
+		<code><a href="source-class-DSchoenbauer.Orm.Events.Persistence.PdoUpdate.html#93-103" title="Go to source code">setUpdate</a>( <span>DSchoenbauer\Sql\Command\Update <var>$update</var> = <span class="php-keyword1">null</span></span> )</code>
 
 		<div class="description short">
 			<p>Object that contains the update logic</p>

--- a/docs/class-DSchoenbauer.Orm.Events.Validate.AbstractValidate.html
+++ b/docs/class-DSchoenbauer.Orm.Events.Validate.AbstractValidate.html
@@ -555,6 +555,7 @@
 	<caption>Methods inherited from <a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#methods">DSchoenbauer\Orm\Events\AbstractEvent</a></caption>
 	<tr>
 		<td><code>
+			<a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#___construct">__construct()</a>, 
 			<a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#_getEvents">getEvents()</a>, 
 			<a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#_setEvents">setEvents()</a>, 
 			<a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#_visitModel">visitModel()</a>

--- a/docs/class-DSchoenbauer.Orm.Events.Validate.DataType.AbstractDataType.html
+++ b/docs/class-DSchoenbauer.Orm.Events.Validate.DataType.AbstractDataType.html
@@ -303,6 +303,7 @@
 	<caption>Methods inherited from <a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#methods">DSchoenbauer\Orm\Events\AbstractEvent</a></caption>
 	<tr>
 		<td><code>
+			<a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#___construct">__construct()</a>, 
 			<a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#_getEvents">getEvents()</a>, 
 			<a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#_setEvents">setEvents()</a>, 
 			<a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#_visitModel">visitModel()</a>

--- a/docs/class-DSchoenbauer.Orm.Events.Validate.DataType.DataTypeBoolean.html
+++ b/docs/class-DSchoenbauer.Orm.Events.Validate.DataType.DataTypeBoolean.html
@@ -345,6 +345,7 @@
 	<caption>Methods inherited from <a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#methods">DSchoenbauer\Orm\Events\AbstractEvent</a></caption>
 	<tr>
 		<td><code>
+			<a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#___construct">__construct()</a>, 
 			<a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#_getEvents">getEvents()</a>, 
 			<a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#_setEvents">setEvents()</a>, 
 			<a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#_visitModel">visitModel()</a>

--- a/docs/class-DSchoenbauer.Orm.Events.Validate.DataType.DataTypeDate.html
+++ b/docs/class-DSchoenbauer.Orm.Events.Validate.DataType.DataTypeDate.html
@@ -426,6 +426,7 @@
 	<caption>Methods inherited from <a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#methods">DSchoenbauer\Orm\Events\AbstractEvent</a></caption>
 	<tr>
 		<td><code>
+			<a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#___construct">__construct()</a>, 
 			<a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#_getEvents">getEvents()</a>, 
 			<a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#_setEvents">setEvents()</a>, 
 			<a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#_visitModel">visitModel()</a>

--- a/docs/class-DSchoenbauer.Orm.Events.Validate.DataType.DataTypeNumber.html
+++ b/docs/class-DSchoenbauer.Orm.Events.Validate.DataType.DataTypeNumber.html
@@ -345,6 +345,7 @@
 	<caption>Methods inherited from <a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#methods">DSchoenbauer\Orm\Events\AbstractEvent</a></caption>
 	<tr>
 		<td><code>
+			<a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#___construct">__construct()</a>, 
 			<a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#_getEvents">getEvents()</a>, 
 			<a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#_setEvents">setEvents()</a>, 
 			<a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#_visitModel">visitModel()</a>

--- a/docs/class-DSchoenbauer.Orm.Events.Validate.DataType.DataTypeString.html
+++ b/docs/class-DSchoenbauer.Orm.Events.Validate.DataType.DataTypeString.html
@@ -345,6 +345,7 @@
 	<caption>Methods inherited from <a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#methods">DSchoenbauer\Orm\Events\AbstractEvent</a></caption>
 	<tr>
 		<td><code>
+			<a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#___construct">__construct()</a>, 
 			<a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#_getEvents">getEvents()</a>, 
 			<a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#_setEvents">setEvents()</a>, 
 			<a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#_visitModel">visitModel()</a>

--- a/docs/class-DSchoenbauer.Orm.Events.Validate.Schema.DefaultValue.html
+++ b/docs/class-DSchoenbauer.Orm.Events.Validate.Schema.DefaultValue.html
@@ -175,7 +175,7 @@
 
 				<b>Author:</b>
 				David Schoenbauer<br>
-			<b>Located at</b> <a href="source-class-DSchoenbauer.Orm.Events.Validate.Schema.DefaultValue.html#31-77" title="Go to source code">Orm/Events/Validate/Schema/DefaultValue.php</a>
+			<b>Located at</b> <a href="source-class-DSchoenbauer.Orm.Events.Validate.Schema.DefaultValue.html#30-69" title="Go to source code">Orm/Events/Validate/Schema/DefaultValue.php</a>
 		<br>
 	</div>
 
@@ -195,7 +195,7 @@
 
 		<td class="name"><div>
 		<a class="anchor" href="#_getFields">#</a>
-		<code><a href="source-class-DSchoenbauer.Orm.Events.Validate.Schema.DefaultValue.html#39-48" title="Go to source code">getFields</a>( <span><code><a href="class-DSchoenbauer.Orm.Entity.HasDefaultValuesInterface.html">DSchoenbauer\Orm\Entity\HasDefaultValuesInterface</a></code> <var>$entity</var></span> )</code>
+		<code><a href="source-class-DSchoenbauer.Orm.Events.Validate.Schema.DefaultValue.html#38-47" title="Go to source code">getFields</a>( <span><code><a href="class-DSchoenbauer.Orm.Entity.HasDefaultValuesInterface.html">DSchoenbauer\Orm\Entity\HasDefaultValuesInterface</a></code> <var>$entity</var></span> )</code>
 
 		<div class="description short">
 			<p>provides an associative array that has a key of the field and a value</p>
@@ -238,7 +238,7 @@
 
 		<td class="name"><div>
 		<a class="anchor" href="#_getTypeInterface">#</a>
-		<code><a href="source-class-DSchoenbauer.Orm.Events.Validate.Schema.DefaultValue.html#50-57" title="Go to source code">getTypeInterface</a>( )</code>
+		<code><a href="source-class-DSchoenbauer.Orm.Events.Validate.Schema.DefaultValue.html#49-56" title="Go to source code">getTypeInterface</a>( )</code>
 
 		<div class="description short">
 			
@@ -263,42 +263,6 @@
 		</div>
 		</div></td>
 	</tr>
-	<tr data-order="preExecuteCheck" id="_preExecuteCheck">
-
-		<td class="attributes"><code>
-			 public 
-
-			boolean
-			
-			</code>
-		</td>
-
-		<td class="name"><div>
-		<a class="anchor" href="#_preExecuteCheck">#</a>
-		<code><a href="source-class-DSchoenbauer.Orm.Events.Validate.Schema.DefaultValue.html#59-65" title="Go to source code">preExecuteCheck</a>( )</code>
-
-		<div class="description short">
-			<p>used to check if they validate function is required or relevant</p>
-		</div>
-
-		<div class="description detailed hidden">
-			<p>used to check if they validate function is required or relevant</p>
-
-
-
-				<h4>Returns</h4>
-				<div class="list">
-					boolean
-				</div>
-
-
-
-				<h4>Overrides</h4>
-				<div class="list"><code><a href="class-DSchoenbauer.Orm.Events.Validate.AbstractValidate.html#_preExecuteCheck">DSchoenbauer\Orm\Events\Validate\AbstractValidate::preExecuteCheck()</a></code></div>
-
-		</div>
-		</div></td>
-	</tr>
 	<tr data-order="validate" id="_validate">
 
 		<td class="attributes"><code>
@@ -311,7 +275,7 @@
 
 		<td class="name"><div>
 		<a class="anchor" href="#_validate">#</a>
-		<code><a href="source-class-DSchoenbauer.Orm.Events.Validate.Schema.DefaultValue.html#67-76" title="Go to source code">validate</a>( <span>array <var>$data</var></span>, <span>array <var>$fields</var></span> )</code>
+		<code><a href="source-class-DSchoenbauer.Orm.Events.Validate.Schema.DefaultValue.html#59-68" title="Go to source code">validate</a>( <span>array <var>$data</var></span>, <span>array <var>$fields</var></span> )</code>
 
 		<div class="description short">
 			
@@ -349,6 +313,7 @@
 			<a href="class-DSchoenbauer.Orm.Events.Validate.AbstractValidate.html#_getModel">getModel()</a>, 
 			<a href="class-DSchoenbauer.Orm.Events.Validate.AbstractValidate.html#_getParams">getParams()</a>, 
 			<a href="class-DSchoenbauer.Orm.Events.Validate.AbstractValidate.html#_onExecute">onExecute()</a>, 
+			<a href="class-DSchoenbauer.Orm.Events.Validate.AbstractValidate.html#_preExecuteCheck">preExecuteCheck()</a>, 
 			<a href="class-DSchoenbauer.Orm.Events.Validate.AbstractValidate.html#_setModel">setModel()</a>, 
 			<a href="class-DSchoenbauer.Orm.Events.Validate.AbstractValidate.html#_setParams">setParams()</a>
 		</code></td>
@@ -358,6 +323,7 @@
 	<caption>Methods inherited from <a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#methods">DSchoenbauer\Orm\Events\AbstractEvent</a></caption>
 	<tr>
 		<td><code>
+			<a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#___construct">__construct()</a>, 
 			<a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#_getEvents">getEvents()</a>, 
 			<a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#_setEvents">setEvents()</a>, 
 			<a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#_visitModel">visitModel()</a>

--- a/docs/class-DSchoenbauer.Orm.Events.Validate.Schema.RequiredFields.html
+++ b/docs/class-DSchoenbauer.Orm.Events.Validate.Schema.RequiredFields.html
@@ -328,6 +328,7 @@
 	<caption>Methods inherited from <a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#methods">DSchoenbauer\Orm\Events\AbstractEvent</a></caption>
 	<tr>
 		<td><code>
+			<a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#___construct">__construct()</a>, 
 			<a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#_getEvents">getEvents()</a>, 
 			<a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#_setEvents">setEvents()</a>, 
 			<a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#_visitModel">visitModel()</a>

--- a/docs/class-DSchoenbauer.Orm.Events.Validate.Schema.ValidFields.html
+++ b/docs/class-DSchoenbauer.Orm.Events.Validate.Schema.ValidFields.html
@@ -328,6 +328,7 @@
 	<caption>Methods inherited from <a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#methods">DSchoenbauer\Orm\Events\AbstractEvent</a></caption>
 	<tr>
 		<td><code>
+			<a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#___construct">__construct()</a>, 
 			<a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#_getEvents">getEvents()</a>, 
 			<a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#_setEvents">setEvents()</a>, 
 			<a href="class-DSchoenbauer.Orm.Events.AbstractEvent.html#_visitModel">visitModel()</a>

--- a/docs/source-class-DSchoenbauer.Orm.CrudModel.html
+++ b/docs/source-class-DSchoenbauer.Orm.CrudModel.html
@@ -208,8 +208,8 @@
 </span><span id="43" class="l"><a href="#43"> 43: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> create(<span class="php-var">$data</span>)
 </span><span id="44" class="l"><a href="#44"> 44: </a>    {
 </span><span id="45" class="l"><a href="#45"> 45: </a>        <span class="php-var">$this</span>-&gt;setData(<span class="php-var">$data</span>);
-</span><span id="46" class="l"><a href="#46"> 46: </a>        <span class="php-var">$events</span> = [ModelEvents::CREATE, ModelEvents::FETCH];
-</span><span id="47" class="l"><a href="#47"> 47: </a>        <span class="php-var">$this</span>-&gt;processEvents(<span class="php-var">$events</span>);
+</span><span id="46" class="l"><a href="#46"> 46: </a>        <span class="php-var">$this</span>-&gt;getEventManager()-&gt;trigger(ModelEvents::CREATE, <span class="php-var">$this</span>);
+</span><span id="47" class="l"><a href="#47"> 47: </a>        <span class="php-var">$this</span>-&gt;getEventManager()-&gt;trigger(ModelEvents::FETCH, <span class="php-var">$this</span>);
 </span><span id="48" class="l"><a href="#48"> 48: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>-&gt;getData();
 </span><span id="49" class="l"><a href="#49"> 49: </a>    }
 </span><span id="50" class="l"><a href="#50"> 50: </a>
@@ -222,72 +222,50 @@
 </span><span id="57" class="l"><a href="#57"> 57: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> fetch(<span class="php-var">$id</span>)
 </span><span id="58" class="l"><a href="#58"> 58: </a>    {
 </span><span id="59" class="l"><a href="#59"> 59: </a>        <span class="php-var">$this</span>-&gt;setId(<span class="php-var">$id</span>);
-</span><span id="60" class="l"><a href="#60"> 60: </a>        <span class="php-var">$events</span> = [ModelEvents::FETCH];
-</span><span id="61" class="l"><a href="#61"> 61: </a>        <span class="php-var">$this</span>-&gt;processEvents(<span class="php-var">$events</span>);
-</span><span id="62" class="l"><a href="#62"> 62: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>-&gt;getData();
-</span><span id="63" class="l"><a href="#63"> 63: </a>    }
-</span><span id="64" class="l"><a href="#64"> 64: </a>
-</span><span id="65" class="l"><a href="#65"> 65: </a>    <span class="php-comment">/**
-</span></span><span id="66" class="l"><a href="#66"> 66: </a><span class="php-comment">     * Process the return of a collection of data
-</span></span><span id="67" class="l"><a href="#67"> 67: </a><span class="php-comment">     * @return array
-</span></span><span id="68" class="l"><a href="#68"> 68: </a><span class="php-comment">     * @since v1.0.0
-</span></span><span id="69" class="l"><a href="#69"> 69: </a><span class="php-comment">     */</span>
-</span><span id="70" class="l"><a href="#70"> 70: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> fetchAll()
-</span><span id="71" class="l"><a href="#71"> 71: </a>    {
-</span><span id="72" class="l"><a href="#72"> 72: </a>        <span class="php-var">$events</span> = [ModelEvents::FETCH_ALL];
-</span><span id="73" class="l"><a href="#73"> 73: </a>        <span class="php-var">$this</span>-&gt;processEvents(<span class="php-var">$events</span>);
-</span><span id="74" class="l"><a href="#74"> 74: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>-&gt;getData();
-</span><span id="75" class="l"><a href="#75"> 75: </a>    }
-</span><span id="76" class="l"><a href="#76"> 76: </a>
-</span><span id="77" class="l"><a href="#77"> 77: </a>    <span class="php-comment">/**
-</span></span><span id="78" class="l"><a href="#78"> 78: </a><span class="php-comment">     * Process the update of data for a given id
-</span></span><span id="79" class="l"><a href="#79"> 79: </a><span class="php-comment">     * @param integer $id primary id number of the record to be updated
-</span></span><span id="80" class="l"><a href="#80"> 80: </a><span class="php-comment">     * @param array $data an associative array of the data to be updated
-</span></span><span id="81" class="l"><a href="#81"> 81: </a><span class="php-comment">     * @return array
-</span></span><span id="82" class="l"><a href="#82"> 82: </a><span class="php-comment">     * @since v1.0.0
-</span></span><span id="83" class="l"><a href="#83"> 83: </a><span class="php-comment">     */</span>
-</span><span id="84" class="l"><a href="#84"> 84: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> update(<span class="php-var">$id</span>, <span class="php-var">$data</span>)
-</span><span id="85" class="l"><a href="#85"> 85: </a>    {
-</span><span id="86" class="l"><a href="#86"> 86: </a>        <span class="php-var">$this</span>-&gt;setId(<span class="php-var">$id</span>)-&gt;setData(<span class="php-var">$data</span>);
-</span><span id="87" class="l"><a href="#87"> 87: </a>        <span class="php-var">$events</span> = [ModelEvents::UPDATE, ModelEvents::FETCH];
-</span><span id="88" class="l"><a href="#88"> 88: </a>        <span class="php-var">$this</span>-&gt;processEvents(<span class="php-var">$events</span>);
-</span><span id="89" class="l"><a href="#89"> 89: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>-&gt;getData();
-</span><span id="90" class="l"><a href="#90"> 90: </a>    }
-</span><span id="91" class="l"><a href="#91"> 91: </a>
-</span><span id="92" class="l"><a href="#92"> 92: </a>    <span class="php-comment">/**
-</span></span><span id="93" class="l"><a href="#93"> 93: </a><span class="php-comment">     * Process the removal of a given record
-</span></span><span id="94" class="l"><a href="#94"> 94: </a><span class="php-comment">     * @param integer $id primary ID of a value to be removed
-</span></span><span id="95" class="l"><a href="#95"> 95: </a><span class="php-comment">     * @return boolean returns true on success
-</span></span><span id="96" class="l"><a href="#96"> 96: </a><span class="php-comment">     * @since v1.0.0
-</span></span><span id="97" class="l"><a href="#97"> 97: </a><span class="php-comment">     */</span>
-</span><span id="98" class="l"><a href="#98"> 98: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> <span class="php-keyword2">delete</span>(<span class="php-var">$id</span>)
-</span><span id="99" class="l"><a href="#99"> 99: </a>    {
-</span><span id="100" class="l"><a href="#100">100: </a>        <span class="php-var">$this</span>-&gt;setId(<span class="php-var">$id</span>);
-</span><span id="101" class="l"><a href="#101">101: </a>        <span class="php-var">$events</span> = [ModelEvents::<span class="php-keyword2">DELETE</span>];
-</span><span id="102" class="l"><a href="#102">102: </a>        <span class="php-var">$this</span>-&gt;processEvents(<span class="php-var">$events</span>);
-</span><span id="103" class="l"><a href="#103">103: </a>        <span class="php-keyword1">return</span> <span class="php-keyword1">true</span>;
-</span><span id="104" class="l"><a href="#104">104: </a>    }
-</span><span id="105" class="l"><a href="#105">105: </a>
-</span><span id="106" class="l"><a href="#106">106: </a>    <span class="php-comment">/**
-</span></span><span id="107" class="l"><a href="#107">107: </a><span class="php-comment">     * Attaches given events into the event manager
-</span></span><span id="108" class="l"><a href="#108">108: </a><span class="php-comment">     * @param array $events
-</span></span><span id="109" class="l"><a href="#109">109: </a><span class="php-comment">     * @return CrudModel
-</span></span><span id="110" class="l"><a href="#110">110: </a><span class="php-comment">     * @since v1.0.0
-</span></span><span id="111" class="l"><a href="#111">111: </a><span class="php-comment">     */</span>
-</span><span id="112" class="l"><a href="#112">112: </a>    <span class="php-keyword1">protected</span> <span class="php-keyword1">function</span> processEvents(<span class="php-keyword1">array</span> <span class="php-var">$events</span>)
-</span><span id="113" class="l"><a href="#113">113: </a>    {
-</span><span id="114" class="l"><a href="#114">114: </a>        <span class="php-var">$this</span>-&gt;getEventManager()-&gt;trigger(
-</span><span id="115" class="l"><a href="#115">115: </a>            ModelEvents::VALIDATE,
-</span><span id="116" class="l"><a href="#116">116: </a>            <span class="php-var">$this</span>,
-</span><span id="117" class="l"><a href="#117">117: </a>            <span class="php-keyword2">compact</span>(<span class="php-quote">'events'</span>)
-</span><span id="118" class="l"><a href="#118">118: </a>        );
-</span><span id="119" class="l"><a href="#119">119: </a>        <span class="php-keyword1">foreach</span> (<span class="php-var">$events</span> <span class="php-keyword1">as</span> <span class="php-var">$event</span>) {
-</span><span id="120" class="l"><a href="#120">120: </a>            <span class="php-var">$this</span>-&gt;getEventManager()-&gt;trigger(<span class="php-var">$event</span>, <span class="php-var">$this</span>);
-</span><span id="121" class="l"><a href="#121">121: </a>        }
-</span><span id="122" class="l"><a href="#122">122: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>;
-</span><span id="123" class="l"><a href="#123">123: </a>    }
-</span><span id="124" class="l"><a href="#124">124: </a>}
-</span><span id="125" class="l"><a href="#125">125: </a></span></code></pre>
+</span><span id="60" class="l"><a href="#60"> 60: </a>        <span class="php-var">$this</span>-&gt;getEventManager()-&gt;trigger(ModelEvents::FETCH, <span class="php-var">$this</span>);
+</span><span id="61" class="l"><a href="#61"> 61: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>-&gt;getData();
+</span><span id="62" class="l"><a href="#62"> 62: </a>    }
+</span><span id="63" class="l"><a href="#63"> 63: </a>
+</span><span id="64" class="l"><a href="#64"> 64: </a>    <span class="php-comment">/**
+</span></span><span id="65" class="l"><a href="#65"> 65: </a><span class="php-comment">     * Process the return of a collection of data
+</span></span><span id="66" class="l"><a href="#66"> 66: </a><span class="php-comment">     * @return array
+</span></span><span id="67" class="l"><a href="#67"> 67: </a><span class="php-comment">     * @since v1.0.0
+</span></span><span id="68" class="l"><a href="#68"> 68: </a><span class="php-comment">     */</span>
+</span><span id="69" class="l"><a href="#69"> 69: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> fetchAll()
+</span><span id="70" class="l"><a href="#70"> 70: </a>    {
+</span><span id="71" class="l"><a href="#71"> 71: </a>        <span class="php-var">$this</span>-&gt;getEventManager()-&gt;trigger(ModelEvents::FETCH_ALL, <span class="php-var">$this</span>);
+</span><span id="72" class="l"><a href="#72"> 72: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>-&gt;getData();
+</span><span id="73" class="l"><a href="#73"> 73: </a>    }
+</span><span id="74" class="l"><a href="#74"> 74: </a>
+</span><span id="75" class="l"><a href="#75"> 75: </a>    <span class="php-comment">/**
+</span></span><span id="76" class="l"><a href="#76"> 76: </a><span class="php-comment">     * Process the update of data for a given id
+</span></span><span id="77" class="l"><a href="#77"> 77: </a><span class="php-comment">     * @param integer $id primary id number of the record to be updated
+</span></span><span id="78" class="l"><a href="#78"> 78: </a><span class="php-comment">     * @param array $data an associative array of the data to be updated
+</span></span><span id="79" class="l"><a href="#79"> 79: </a><span class="php-comment">     * @return array
+</span></span><span id="80" class="l"><a href="#80"> 80: </a><span class="php-comment">     * @since v1.0.0
+</span></span><span id="81" class="l"><a href="#81"> 81: </a><span class="php-comment">     */</span>
+</span><span id="82" class="l"><a href="#82"> 82: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> update(<span class="php-var">$id</span>, <span class="php-var">$data</span>)
+</span><span id="83" class="l"><a href="#83"> 83: </a>    {
+</span><span id="84" class="l"><a href="#84"> 84: </a>        <span class="php-var">$this</span>-&gt;setId(<span class="php-var">$id</span>)-&gt;setData(<span class="php-var">$data</span>);
+</span><span id="85" class="l"><a href="#85"> 85: </a>        <span class="php-var">$this</span>-&gt;getEventManager()-&gt;trigger(ModelEvents::UPDATE, <span class="php-var">$this</span>);
+</span><span id="86" class="l"><a href="#86"> 86: </a>        <span class="php-var">$this</span>-&gt;getEventManager()-&gt;trigger(ModelEvents::FETCH, <span class="php-var">$this</span>);
+</span><span id="87" class="l"><a href="#87"> 87: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>-&gt;getData();
+</span><span id="88" class="l"><a href="#88"> 88: </a>    }
+</span><span id="89" class="l"><a href="#89"> 89: </a>
+</span><span id="90" class="l"><a href="#90"> 90: </a>    <span class="php-comment">/**
+</span></span><span id="91" class="l"><a href="#91"> 91: </a><span class="php-comment">     * Process the removal of a given record
+</span></span><span id="92" class="l"><a href="#92"> 92: </a><span class="php-comment">     * @param integer $id primary ID of a value to be removed
+</span></span><span id="93" class="l"><a href="#93"> 93: </a><span class="php-comment">     * @return boolean returns true on success
+</span></span><span id="94" class="l"><a href="#94"> 94: </a><span class="php-comment">     * @since v1.0.0
+</span></span><span id="95" class="l"><a href="#95"> 95: </a><span class="php-comment">     */</span>
+</span><span id="96" class="l"><a href="#96"> 96: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> <span class="php-keyword2">delete</span>(<span class="php-var">$id</span>)
+</span><span id="97" class="l"><a href="#97"> 97: </a>    {
+</span><span id="98" class="l"><a href="#98"> 98: </a>        <span class="php-var">$this</span>-&gt;setId(<span class="php-var">$id</span>);
+</span><span id="99" class="l"><a href="#99"> 99: </a>        <span class="php-var">$this</span>-&gt;getEventManager()-&gt;trigger(ModelEvents::<span class="php-keyword2">DELETE</span>, <span class="php-var">$this</span>);
+</span><span id="100" class="l"><a href="#100">100: </a>        <span class="php-keyword1">return</span> <span class="php-keyword1">true</span>;
+</span><span id="101" class="l"><a href="#101">101: </a>    }
+</span><span id="102" class="l"><a href="#102">102: </a>}
+</span><span id="103" class="l"><a href="#103">103: </a></span></code></pre>
 
 	<div id="footer">
 		 API documentation generated by <a href="http://apigen.org">ApiGen</a>

--- a/docs/source-class-DSchoenbauer.Orm.Enum.ModelEvents.html
+++ b/docs/source-class-DSchoenbauer.Orm.Enum.ModelEvents.html
@@ -196,38 +196,33 @@
 </span></span><span id="31" class="l"><a href="#31">31: </a><span class="php-comment"> */</span>
 </span><span id="32" class="l"><a href="#32">32: </a><span class="php-keyword1">class</span> ModelEvents
 </span><span id="33" class="l"><a href="#33">33: </a>{
-</span><span id="34" class="l"><a href="#34">34: </a>
+</span><span id="34" class="l"><a href="#34">34: </a>    
 </span><span id="35" class="l"><a href="#35">35: </a>    <span class="php-comment">/**
-</span></span><span id="36" class="l"><a href="#36">36: </a><span class="php-comment">     * Called to validate data
+</span></span><span id="36" class="l"><a href="#36">36: </a><span class="php-comment">     * Called to create a new record
 </span></span><span id="37" class="l"><a href="#37">37: </a><span class="php-comment">     */</span>
-</span><span id="38" class="l"><a href="#38">38: </a>    <span class="php-keyword1">const</span> VALIDATE = <span class="php-quote">'validate'</span>;
+</span><span id="38" class="l"><a href="#38">38: </a>    <span class="php-keyword1">const</span> CREATE = <span class="php-quote">'create'</span>;
 </span><span id="39" class="l"><a href="#39">39: </a>    
 </span><span id="40" class="l"><a href="#40">40: </a>    <span class="php-comment">/**
-</span></span><span id="41" class="l"><a href="#41">41: </a><span class="php-comment">     * Called to create a new record
+</span></span><span id="41" class="l"><a href="#41">41: </a><span class="php-comment">     * Called to retrieve a given record
 </span></span><span id="42" class="l"><a href="#42">42: </a><span class="php-comment">     */</span>
-</span><span id="43" class="l"><a href="#43">43: </a>    <span class="php-keyword1">const</span> CREATE = <span class="php-quote">'create'</span>;
+</span><span id="43" class="l"><a href="#43">43: </a>    <span class="php-keyword1">const</span> FETCH = <span class="php-quote">&quot;fetch&quot;</span>;
 </span><span id="44" class="l"><a href="#44">44: </a>    
 </span><span id="45" class="l"><a href="#45">45: </a>    <span class="php-comment">/**
-</span></span><span id="46" class="l"><a href="#46">46: </a><span class="php-comment">     * Called to retrieve a given record
+</span></span><span id="46" class="l"><a href="#46">46: </a><span class="php-comment">     * Called to retrieve a collection of records
 </span></span><span id="47" class="l"><a href="#47">47: </a><span class="php-comment">     */</span>
-</span><span id="48" class="l"><a href="#48">48: </a>    <span class="php-keyword1">const</span> FETCH = <span class="php-quote">&quot;fetch&quot;</span>;
+</span><span id="48" class="l"><a href="#48">48: </a>    <span class="php-keyword1">const</span> FETCH_ALL = <span class="php-quote">&quot;fetchAll&quot;</span>;
 </span><span id="49" class="l"><a href="#49">49: </a>    
 </span><span id="50" class="l"><a href="#50">50: </a>    <span class="php-comment">/**
-</span></span><span id="51" class="l"><a href="#51">51: </a><span class="php-comment">     * Called to retrieve a collection of records
+</span></span><span id="51" class="l"><a href="#51">51: </a><span class="php-comment">     * Called to update a record with data
 </span></span><span id="52" class="l"><a href="#52">52: </a><span class="php-comment">     */</span>
-</span><span id="53" class="l"><a href="#53">53: </a>    <span class="php-keyword1">const</span> FETCH_ALL = <span class="php-quote">&quot;fetchAll&quot;</span>;
+</span><span id="53" class="l"><a href="#53">53: </a>    <span class="php-keyword1">const</span> UPDATE = <span class="php-quote">'update'</span>;
 </span><span id="54" class="l"><a href="#54">54: </a>    
 </span><span id="55" class="l"><a href="#55">55: </a>    <span class="php-comment">/**
-</span></span><span id="56" class="l"><a href="#56">56: </a><span class="php-comment">     * Called to update a record with data
+</span></span><span id="56" class="l"><a href="#56">56: </a><span class="php-comment">     * Called to remove data, be it one or many records
 </span></span><span id="57" class="l"><a href="#57">57: </a><span class="php-comment">     */</span>
-</span><span id="58" class="l"><a href="#58">58: </a>    <span class="php-keyword1">const</span> UPDATE = <span class="php-quote">'update'</span>;
-</span><span id="59" class="l"><a href="#59">59: </a>    
-</span><span id="60" class="l"><a href="#60">60: </a>    <span class="php-comment">/**
-</span></span><span id="61" class="l"><a href="#61">61: </a><span class="php-comment">     * Called to remove data, be it one or many records
-</span></span><span id="62" class="l"><a href="#62">62: </a><span class="php-comment">     */</span>
-</span><span id="63" class="l"><a href="#63">63: </a>    <span class="php-keyword1">const</span> <span class="php-keyword2">DELETE</span> = <span class="php-quote">'delete'</span>;
-</span><span id="64" class="l"><a href="#64">64: </a>}
-</span><span id="65" class="l"><a href="#65">65: </a></span></code></pre>
+</span><span id="58" class="l"><a href="#58">58: </a>    <span class="php-keyword1">const</span> <span class="php-keyword2">DELETE</span> = <span class="php-quote">'delete'</span>;
+</span><span id="59" class="l"><a href="#59">59: </a>}
+</span><span id="60" class="l"><a href="#60">60: </a></span></code></pre>
 
 	<div id="footer">
 		 API documentation generated by <a href="http://apigen.org">ApiGen</a>

--- a/docs/source-class-DSchoenbauer.Orm.Events.AbstractEvent.html
+++ b/docs/source-class-DSchoenbauer.Orm.Events.AbstractEvent.html
@@ -202,44 +202,50 @@
 </span><span id="37" class="l"><a href="#37">37: </a>{
 </span><span id="38" class="l"><a href="#38">38: </a>
 </span><span id="39" class="l"><a href="#39">39: </a>    <span class="php-keyword1">private</span> <span class="php-var">$events</span> = [];
-</span><span id="40" class="l"><a href="#40">40: </a>
-</span><span id="41" class="l"><a href="#41">41: </a>    <span class="php-comment">/**
-</span></span><span id="42" class="l"><a href="#42">42: </a><span class="php-comment">     * provides an opportunity to extend Model's functionality
-</span></span><span id="43" class="l"><a href="#43">43: </a><span class="php-comment">     * @param Model $model model with which to be listened to
-</span></span><span id="44" class="l"><a href="#44">44: </a><span class="php-comment">     * @since v1.0.0
-</span></span><span id="45" class="l"><a href="#45">45: </a><span class="php-comment">     */</span>
-</span><span id="46" class="l"><a href="#46">46: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> visitModel(Model <span class="php-var">$model</span>)
-</span><span id="47" class="l"><a href="#47">47: </a>    {
-</span><span id="48" class="l"><a href="#48">48: </a>        <span class="php-keyword1">foreach</span> (<span class="php-var">$this</span>-&gt;getEvents() <span class="php-keyword1">as</span> <span class="php-var">$event</span>) {
-</span><span id="49" class="l"><a href="#49">49: </a>            <span class="php-var">$model</span>-&gt;getEventManager()-&gt;attach(<span class="php-var">$event</span>, [<span class="php-var">$this</span>, <span class="php-quote">'onExecute'</span>]);
-</span><span id="50" class="l"><a href="#50">50: </a>        }
-</span><span id="51" class="l"><a href="#51">51: </a>    }
-</span><span id="52" class="l"><a href="#52">52: </a>
-</span><span id="53" class="l"><a href="#53">53: </a>    <span class="php-keyword1">abstract</span> <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> onExecute(Event <span class="php-var">$event</span>);
-</span><span id="54" class="l"><a href="#54">54: </a>
-</span><span id="55" class="l"><a href="#55">55: </a>    <span class="php-comment">/**
-</span></span><span id="56" class="l"><a href="#56">56: </a><span class="php-comment">     * returns a list of event names that this object should be executed
-</span></span><span id="57" class="l"><a href="#57">57: </a><span class="php-comment">     * @return array
-</span></span><span id="58" class="l"><a href="#58">58: </a><span class="php-comment">     * @since v1.0.0
-</span></span><span id="59" class="l"><a href="#59">59: </a><span class="php-comment">     **/</span>
-</span><span id="60" class="l"><a href="#60">60: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> getEvents()
-</span><span id="61" class="l"><a href="#61">61: </a>    {
-</span><span id="62" class="l"><a href="#62">62: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>-&gt;events;
-</span><span id="63" class="l"><a href="#63">63: </a>    }
-</span><span id="64" class="l"><a href="#64">64: </a>
-</span><span id="65" class="l"><a href="#65">65: </a>    <span class="php-comment">/**
-</span></span><span id="66" class="l"><a href="#66">66: </a><span class="php-comment">     * defines a list of event names this object will listen for to execute
-</span></span><span id="67" class="l"><a href="#67">67: </a><span class="php-comment">     * @param array $events array of event to be executed with
-</span></span><span id="68" class="l"><a href="#68">68: </a><span class="php-comment">     * @return $this
-</span></span><span id="69" class="l"><a href="#69">69: </a><span class="php-comment">     * @since v1.0.0
-</span></span><span id="70" class="l"><a href="#70">70: </a><span class="php-comment">     */</span>
-</span><span id="71" class="l"><a href="#71">71: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> setEvents(<span class="php-keyword1">array</span> <span class="php-var">$events</span>)
-</span><span id="72" class="l"><a href="#72">72: </a>    {
-</span><span id="73" class="l"><a href="#73">73: </a>        <span class="php-var">$this</span>-&gt;events = <span class="php-var">$events</span>;
-</span><span id="74" class="l"><a href="#74">74: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>;
-</span><span id="75" class="l"><a href="#75">75: </a>    }
-</span><span id="76" class="l"><a href="#76">76: </a>}
-</span><span id="77" class="l"><a href="#77">77: </a></span></code></pre>
+</span><span id="40" class="l"><a href="#40">40: </a>    
+</span><span id="41" class="l"><a href="#41">41: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> __construct(<span class="php-keyword1">array</span> <span class="php-var">$events</span> = [])
+</span><span id="42" class="l"><a href="#42">42: </a>    {
+</span><span id="43" class="l"><a href="#43">43: </a>        <span class="php-var">$this</span>-&gt;setEvents(<span class="php-var">$events</span>);
+</span><span id="44" class="l"><a href="#44">44: </a>    }
+</span><span id="45" class="l"><a href="#45">45: </a>    
+</span><span id="46" class="l"><a href="#46">46: </a>
+</span><span id="47" class="l"><a href="#47">47: </a>    <span class="php-comment">/**
+</span></span><span id="48" class="l"><a href="#48">48: </a><span class="php-comment">     * provides an opportunity to extend Model's functionality
+</span></span><span id="49" class="l"><a href="#49">49: </a><span class="php-comment">     * @param Model $model model with which to be listened to
+</span></span><span id="50" class="l"><a href="#50">50: </a><span class="php-comment">     * @since v1.0.0
+</span></span><span id="51" class="l"><a href="#51">51: </a><span class="php-comment">     */</span>
+</span><span id="52" class="l"><a href="#52">52: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> visitModel(Model <span class="php-var">$model</span>)
+</span><span id="53" class="l"><a href="#53">53: </a>    {
+</span><span id="54" class="l"><a href="#54">54: </a>        <span class="php-keyword1">foreach</span> (<span class="php-var">$this</span>-&gt;getEvents() <span class="php-keyword1">as</span> <span class="php-var">$event</span>) {
+</span><span id="55" class="l"><a href="#55">55: </a>            <span class="php-var">$model</span>-&gt;getEventManager()-&gt;attach(<span class="php-var">$event</span>, [<span class="php-var">$this</span>, <span class="php-quote">'onExecute'</span>]);
+</span><span id="56" class="l"><a href="#56">56: </a>        }
+</span><span id="57" class="l"><a href="#57">57: </a>    }
+</span><span id="58" class="l"><a href="#58">58: </a>
+</span><span id="59" class="l"><a href="#59">59: </a>    <span class="php-keyword1">abstract</span> <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> onExecute(Event <span class="php-var">$event</span>);
+</span><span id="60" class="l"><a href="#60">60: </a>
+</span><span id="61" class="l"><a href="#61">61: </a>    <span class="php-comment">/**
+</span></span><span id="62" class="l"><a href="#62">62: </a><span class="php-comment">     * returns a list of event names that this object should be executed
+</span></span><span id="63" class="l"><a href="#63">63: </a><span class="php-comment">     * @return array
+</span></span><span id="64" class="l"><a href="#64">64: </a><span class="php-comment">     * @since v1.0.0
+</span></span><span id="65" class="l"><a href="#65">65: </a><span class="php-comment">     **/</span>
+</span><span id="66" class="l"><a href="#66">66: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> getEvents()
+</span><span id="67" class="l"><a href="#67">67: </a>    {
+</span><span id="68" class="l"><a href="#68">68: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>-&gt;events;
+</span><span id="69" class="l"><a href="#69">69: </a>    }
+</span><span id="70" class="l"><a href="#70">70: </a>
+</span><span id="71" class="l"><a href="#71">71: </a>    <span class="php-comment">/**
+</span></span><span id="72" class="l"><a href="#72">72: </a><span class="php-comment">     * defines a list of event names this object will listen for to execute
+</span></span><span id="73" class="l"><a href="#73">73: </a><span class="php-comment">     * @param array $events array of event to be executed with
+</span></span><span id="74" class="l"><a href="#74">74: </a><span class="php-comment">     * @return $this
+</span></span><span id="75" class="l"><a href="#75">75: </a><span class="php-comment">     * @since v1.0.0
+</span></span><span id="76" class="l"><a href="#76">76: </a><span class="php-comment">     */</span>
+</span><span id="77" class="l"><a href="#77">77: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> setEvents(<span class="php-keyword1">array</span> <span class="php-var">$events</span>)
+</span><span id="78" class="l"><a href="#78">78: </a>    {
+</span><span id="79" class="l"><a href="#79">79: </a>        <span class="php-var">$this</span>-&gt;events = <span class="php-var">$events</span>;
+</span><span id="80" class="l"><a href="#80">80: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>;
+</span><span id="81" class="l"><a href="#81">81: </a>    }
+</span><span id="82" class="l"><a href="#82">82: </a>}
+</span><span id="83" class="l"><a href="#83">83: </a></span></code></pre>
 
 	<div id="footer">
 		 API documentation generated by <a href="http://apigen.org">ApiGen</a>

--- a/docs/source-class-DSchoenbauer.Orm.Events.Persistence.PdoCreate.html
+++ b/docs/source-class-DSchoenbauer.Orm.Events.Persistence.PdoCreate.html
@@ -191,83 +191,85 @@
 </span><span id="26" class="l"><a href="#26"> 26: </a>
 </span><span id="27" class="l"><a href="#27"> 27: </a>    <span class="php-comment">/**
 </span></span><span id="28" class="l"><a href="#28"> 28: </a><span class="php-comment">     *
-</span></span><span id="29" class="l"><a href="#29"> 29: </a><span class="php-comment">     * @param PDO $adapter PDO connection to a db of some sort.
-</span></span><span id="30" class="l"><a href="#30"> 30: </a><span class="php-comment">     * @param Create $create default null, if no create object offered one will
-</span></span><span id="31" class="l"><a href="#31"> 31: </a><span class="php-comment">     * be lazy loaded for you
-</span></span><span id="32" class="l"><a href="#32"> 32: </a><span class="php-comment">     * @since v1.0.0
-</span></span><span id="33" class="l"><a href="#33"> 33: </a><span class="php-comment">     */</span>
-</span><span id="34" class="l"><a href="#34"> 34: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> __construct(PDO <span class="php-var">$adapter</span>, Create <span class="php-var">$create</span> = <span class="php-keyword1">null</span>)
-</span><span id="35" class="l"><a href="#35"> 35: </a>    {
-</span><span id="36" class="l"><a href="#36"> 36: </a>        <span class="php-var">$this</span>-&gt;setAdapter(<span class="php-var">$adapter</span>)-&gt;setCreate(<span class="php-var">$create</span>);
-</span><span id="37" class="l"><a href="#37"> 37: </a>    }
-</span><span id="38" class="l"><a href="#38"> 38: </a>
-</span><span id="39" class="l"><a href="#39"> 39: </a>    <span class="php-comment">/**
-</span></span><span id="40" class="l"><a href="#40"> 40: </a><span class="php-comment">     * event action
-</span></span><span id="41" class="l"><a href="#41"> 41: </a><span class="php-comment">     * @param Event $event object passed when event is fired
-</span></span><span id="42" class="l"><a href="#42"> 42: </a><span class="php-comment">     * @return void
-</span></span><span id="43" class="l"><a href="#43"> 43: </a><span class="php-comment">     * @since v1.0.0
-</span></span><span id="44" class="l"><a href="#44"> 44: </a><span class="php-comment">     */</span>
-</span><span id="45" class="l"><a href="#45"> 45: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> onExecute(Event <span class="php-var">$event</span>)
-</span><span id="46" class="l"><a href="#46"> 46: </a>    {
-</span><span id="47" class="l"><a href="#47"> 47: </a>        <span class="php-keyword1">if</span> (!<span class="php-var">$event</span>-&gt;getTarget() <span class="php-keyword1">instanceof</span> Model) {
-</span><span id="48" class="l"><a href="#48"> 48: </a>            <span class="php-keyword1">return</span>;
-</span><span id="49" class="l"><a href="#49"> 49: </a>        }
-</span><span id="50" class="l"><a href="#50"> 50: </a>        <span class="php-comment">/* @var $model Model */</span>
-</span><span id="51" class="l"><a href="#51"> 51: </a>        <span class="php-var">$model</span> = <span class="php-var">$event</span>-&gt;getTarget();
-</span><span id="52" class="l"><a href="#52"> 52: </a>        <span class="php-var">$entity</span> = <span class="php-var">$model</span>-&gt;getEntity();
-</span><span id="53" class="l"><a href="#53"> 53: </a>        <span class="php-var">$this</span>-&gt;getCreate()
-</span><span id="54" class="l"><a href="#54"> 54: </a>            -&gt;setTable(<span class="php-var">$entity</span>-&gt;getTable())
-</span><span id="55" class="l"><a href="#55"> 55: </a>            -&gt;setData(<span class="php-var">$model</span>-&gt;getData())
-</span><span id="56" class="l"><a href="#56"> 56: </a>            -&gt;execute(<span class="php-var">$this</span>-&gt;getAdapter());
-</span><span id="57" class="l"><a href="#57"> 57: </a>    }
-</span><span id="58" class="l"><a href="#58"> 58: </a>
-</span><span id="59" class="l"><a href="#59"> 59: </a>    <span class="php-comment">/**
-</span></span><span id="60" class="l"><a href="#60"> 60: </a><span class="php-comment">     * Returns a PHP Data Object
-</span></span><span id="61" class="l"><a href="#61"> 61: </a><span class="php-comment">     * @return PDO
-</span></span><span id="62" class="l"><a href="#62"> 62: </a><span class="php-comment">     * @since v1.0.0
-</span></span><span id="63" class="l"><a href="#63"> 63: </a><span class="php-comment">     */</span>
-</span><span id="64" class="l"><a href="#64"> 64: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> getAdapter()
-</span><span id="65" class="l"><a href="#65"> 65: </a>    {
-</span><span id="66" class="l"><a href="#66"> 66: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>-&gt;adapter;
-</span><span id="67" class="l"><a href="#67"> 67: </a>    }
-</span><span id="68" class="l"><a href="#68"> 68: </a>
-</span><span id="69" class="l"><a href="#69"> 69: </a>    <span class="php-comment">/**
-</span></span><span id="70" class="l"><a href="#70"> 70: </a><span class="php-comment">     * PDO connection to a db of some sort.
-</span></span><span id="71" class="l"><a href="#71"> 71: </a><span class="php-comment">     * @param PDO $adapter
-</span></span><span id="72" class="l"><a href="#72"> 72: </a><span class="php-comment">     * @return $this
-</span></span><span id="73" class="l"><a href="#73"> 73: </a><span class="php-comment">     * @since v1.0.0
-</span></span><span id="74" class="l"><a href="#74"> 74: </a><span class="php-comment">     */</span>
-</span><span id="75" class="l"><a href="#75"> 75: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> setAdapter(PDO <span class="php-var">$adapter</span>)
-</span><span id="76" class="l"><a href="#76"> 76: </a>    {
-</span><span id="77" class="l"><a href="#77"> 77: </a>        <span class="php-var">$this</span>-&gt;adapter = <span class="php-var">$adapter</span>;
-</span><span id="78" class="l"><a href="#78"> 78: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>;
-</span><span id="79" class="l"><a href="#79"> 79: </a>    }
-</span><span id="80" class="l"><a href="#80"> 80: </a>
-</span><span id="81" class="l"><a href="#81"> 81: </a>    <span class="php-comment">/**
-</span></span><span id="82" class="l"><a href="#82"> 82: </a><span class="php-comment">     * object with logic for the Create. If Create is not provided one will be lazy loaded
-</span></span><span id="83" class="l"><a href="#83"> 83: </a><span class="php-comment">     * @return Create object that is used for the create logic
-</span></span><span id="84" class="l"><a href="#84"> 84: </a><span class="php-comment">     * @since v1.0.0
-</span></span><span id="85" class="l"><a href="#85"> 85: </a><span class="php-comment">     */</span>
-</span><span id="86" class="l"><a href="#86"> 86: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> getCreate()
-</span><span id="87" class="l"><a href="#87"> 87: </a>    {
-</span><span id="88" class="l"><a href="#88"> 88: </a>        <span class="php-keyword1">if</span> (!<span class="php-var">$this</span>-&gt;create <span class="php-keyword1">instanceof</span> Create) {
-</span><span id="89" class="l"><a href="#89"> 89: </a>            <span class="php-var">$this</span>-&gt;setCreate(<span class="php-keyword1">new</span> Create(<span class="php-keyword1">null</span>, []));
-</span><span id="90" class="l"><a href="#90"> 90: </a>        }
-</span><span id="91" class="l"><a href="#91"> 91: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>-&gt;create;
-</span><span id="92" class="l"><a href="#92"> 92: </a>    }
-</span><span id="93" class="l"><a href="#93"> 93: </a>
-</span><span id="94" class="l"><a href="#94"> 94: </a>    <span class="php-comment">/**
-</span></span><span id="95" class="l"><a href="#95"> 95: </a><span class="php-comment">     * @param Create $create object with the create logic
-</span></span><span id="96" class="l"><a href="#96"> 96: </a><span class="php-comment">     * @return $this
-</span></span><span id="97" class="l"><a href="#97"> 97: </a><span class="php-comment">     * @since v1.0.0
-</span></span><span id="98" class="l"><a href="#98"> 98: </a><span class="php-comment">     */</span>
-</span><span id="99" class="l"><a href="#99"> 99: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> setCreate(Create <span class="php-var">$create</span> = <span class="php-keyword1">null</span>)
-</span><span id="100" class="l"><a href="#100">100: </a>    {
-</span><span id="101" class="l"><a href="#101">101: </a>        <span class="php-var">$this</span>-&gt;create = <span class="php-var">$create</span>;
-</span><span id="102" class="l"><a href="#102">102: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>;
-</span><span id="103" class="l"><a href="#103">103: </a>    }
-</span><span id="104" class="l"><a href="#104">104: </a>}
-</span><span id="105" class="l"><a href="#105">105: </a></span></code></pre>
+</span></span><span id="29" class="l"><a href="#29"> 29: </a><span class="php-comment">     * @param array $events An array of event names to bind to
+</span></span><span id="30" class="l"><a href="#30"> 30: </a><span class="php-comment">     * @param PDO $adapter PDO connection to a db of some sort.
+</span></span><span id="31" class="l"><a href="#31"> 31: </a><span class="php-comment">     * @param Create $create default null, if no create object offered one will
+</span></span><span id="32" class="l"><a href="#32"> 32: </a><span class="php-comment">     * be lazy loaded for you
+</span></span><span id="33" class="l"><a href="#33"> 33: </a><span class="php-comment">     * @since v1.0.0
+</span></span><span id="34" class="l"><a href="#34"> 34: </a><span class="php-comment">     */</span>
+</span><span id="35" class="l"><a href="#35"> 35: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> __construct(<span class="php-keyword1">array</span> <span class="php-var">$events</span>, PDO <span class="php-var">$adapter</span>, Create <span class="php-var">$create</span> = <span class="php-keyword1">null</span>)
+</span><span id="36" class="l"><a href="#36"> 36: </a>    {
+</span><span id="37" class="l"><a href="#37"> 37: </a>        parent::__construct(<span class="php-var">$events</span>);
+</span><span id="38" class="l"><a href="#38"> 38: </a>        <span class="php-var">$this</span>-&gt;setAdapter(<span class="php-var">$adapter</span>)-&gt;setCreate(<span class="php-var">$create</span>);
+</span><span id="39" class="l"><a href="#39"> 39: </a>    }
+</span><span id="40" class="l"><a href="#40"> 40: </a>
+</span><span id="41" class="l"><a href="#41"> 41: </a>    <span class="php-comment">/**
+</span></span><span id="42" class="l"><a href="#42"> 42: </a><span class="php-comment">     * event action
+</span></span><span id="43" class="l"><a href="#43"> 43: </a><span class="php-comment">     * @param Event $event object passed when event is fired
+</span></span><span id="44" class="l"><a href="#44"> 44: </a><span class="php-comment">     * @return void
+</span></span><span id="45" class="l"><a href="#45"> 45: </a><span class="php-comment">     * @since v1.0.0
+</span></span><span id="46" class="l"><a href="#46"> 46: </a><span class="php-comment">     */</span>
+</span><span id="47" class="l"><a href="#47"> 47: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> onExecute(Event <span class="php-var">$event</span>)
+</span><span id="48" class="l"><a href="#48"> 48: </a>    {
+</span><span id="49" class="l"><a href="#49"> 49: </a>        <span class="php-keyword1">if</span> (!<span class="php-var">$event</span>-&gt;getTarget() <span class="php-keyword1">instanceof</span> Model) {
+</span><span id="50" class="l"><a href="#50"> 50: </a>            <span class="php-keyword1">return</span>;
+</span><span id="51" class="l"><a href="#51"> 51: </a>        }
+</span><span id="52" class="l"><a href="#52"> 52: </a>        <span class="php-comment">/* @var $model Model */</span>
+</span><span id="53" class="l"><a href="#53"> 53: </a>        <span class="php-var">$model</span> = <span class="php-var">$event</span>-&gt;getTarget();
+</span><span id="54" class="l"><a href="#54"> 54: </a>        <span class="php-var">$entity</span> = <span class="php-var">$model</span>-&gt;getEntity();
+</span><span id="55" class="l"><a href="#55"> 55: </a>        <span class="php-var">$this</span>-&gt;getCreate()
+</span><span id="56" class="l"><a href="#56"> 56: </a>            -&gt;setTable(<span class="php-var">$entity</span>-&gt;getTable())
+</span><span id="57" class="l"><a href="#57"> 57: </a>            -&gt;setData(<span class="php-var">$model</span>-&gt;getData())
+</span><span id="58" class="l"><a href="#58"> 58: </a>            -&gt;execute(<span class="php-var">$this</span>-&gt;getAdapter());
+</span><span id="59" class="l"><a href="#59"> 59: </a>    }
+</span><span id="60" class="l"><a href="#60"> 60: </a>
+</span><span id="61" class="l"><a href="#61"> 61: </a>    <span class="php-comment">/**
+</span></span><span id="62" class="l"><a href="#62"> 62: </a><span class="php-comment">     * Returns a PHP Data Object
+</span></span><span id="63" class="l"><a href="#63"> 63: </a><span class="php-comment">     * @return PDO
+</span></span><span id="64" class="l"><a href="#64"> 64: </a><span class="php-comment">     * @since v1.0.0
+</span></span><span id="65" class="l"><a href="#65"> 65: </a><span class="php-comment">     */</span>
+</span><span id="66" class="l"><a href="#66"> 66: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> getAdapter()
+</span><span id="67" class="l"><a href="#67"> 67: </a>    {
+</span><span id="68" class="l"><a href="#68"> 68: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>-&gt;adapter;
+</span><span id="69" class="l"><a href="#69"> 69: </a>    }
+</span><span id="70" class="l"><a href="#70"> 70: </a>
+</span><span id="71" class="l"><a href="#71"> 71: </a>    <span class="php-comment">/**
+</span></span><span id="72" class="l"><a href="#72"> 72: </a><span class="php-comment">     * PDO connection to a db of some sort.
+</span></span><span id="73" class="l"><a href="#73"> 73: </a><span class="php-comment">     * @param PDO $adapter
+</span></span><span id="74" class="l"><a href="#74"> 74: </a><span class="php-comment">     * @return $this
+</span></span><span id="75" class="l"><a href="#75"> 75: </a><span class="php-comment">     * @since v1.0.0
+</span></span><span id="76" class="l"><a href="#76"> 76: </a><span class="php-comment">     */</span>
+</span><span id="77" class="l"><a href="#77"> 77: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> setAdapter(PDO <span class="php-var">$adapter</span>)
+</span><span id="78" class="l"><a href="#78"> 78: </a>    {
+</span><span id="79" class="l"><a href="#79"> 79: </a>        <span class="php-var">$this</span>-&gt;adapter = <span class="php-var">$adapter</span>;
+</span><span id="80" class="l"><a href="#80"> 80: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>;
+</span><span id="81" class="l"><a href="#81"> 81: </a>    }
+</span><span id="82" class="l"><a href="#82"> 82: </a>
+</span><span id="83" class="l"><a href="#83"> 83: </a>    <span class="php-comment">/**
+</span></span><span id="84" class="l"><a href="#84"> 84: </a><span class="php-comment">     * object with logic for the Create. If Create is not provided one will be lazy loaded
+</span></span><span id="85" class="l"><a href="#85"> 85: </a><span class="php-comment">     * @return Create object that is used for the create logic
+</span></span><span id="86" class="l"><a href="#86"> 86: </a><span class="php-comment">     * @since v1.0.0
+</span></span><span id="87" class="l"><a href="#87"> 87: </a><span class="php-comment">     */</span>
+</span><span id="88" class="l"><a href="#88"> 88: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> getCreate()
+</span><span id="89" class="l"><a href="#89"> 89: </a>    {
+</span><span id="90" class="l"><a href="#90"> 90: </a>        <span class="php-keyword1">if</span> (!<span class="php-var">$this</span>-&gt;create <span class="php-keyword1">instanceof</span> Create) {
+</span><span id="91" class="l"><a href="#91"> 91: </a>            <span class="php-var">$this</span>-&gt;setCreate(<span class="php-keyword1">new</span> Create(<span class="php-keyword1">null</span>, []));
+</span><span id="92" class="l"><a href="#92"> 92: </a>        }
+</span><span id="93" class="l"><a href="#93"> 93: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>-&gt;create;
+</span><span id="94" class="l"><a href="#94"> 94: </a>    }
+</span><span id="95" class="l"><a href="#95"> 95: </a>
+</span><span id="96" class="l"><a href="#96"> 96: </a>    <span class="php-comment">/**
+</span></span><span id="97" class="l"><a href="#97"> 97: </a><span class="php-comment">     * @param Create $create object with the create logic
+</span></span><span id="98" class="l"><a href="#98"> 98: </a><span class="php-comment">     * @return $this
+</span></span><span id="99" class="l"><a href="#99"> 99: </a><span class="php-comment">     * @since v1.0.0
+</span></span><span id="100" class="l"><a href="#100">100: </a><span class="php-comment">     */</span>
+</span><span id="101" class="l"><a href="#101">101: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> setCreate(Create <span class="php-var">$create</span> = <span class="php-keyword1">null</span>)
+</span><span id="102" class="l"><a href="#102">102: </a>    {
+</span><span id="103" class="l"><a href="#103">103: </a>        <span class="php-var">$this</span>-&gt;create = <span class="php-var">$create</span>;
+</span><span id="104" class="l"><a href="#104">104: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>;
+</span><span id="105" class="l"><a href="#105">105: </a>    }
+</span><span id="106" class="l"><a href="#106">106: </a>}
+</span><span id="107" class="l"><a href="#107">107: </a></span></code></pre>
 
 	<div id="footer">
 		 API documentation generated by <a href="http://apigen.org">ApiGen</a>

--- a/docs/source-class-DSchoenbauer.Orm.Events.Persistence.PdoDelete.html
+++ b/docs/source-class-DSchoenbauer.Orm.Events.Persistence.PdoDelete.html
@@ -163,104 +163,110 @@
 		</ul>
 	</div>
 
-<pre><code><span id="1" class="l"><a href="#1"> 1: </a><span class="xlang">&lt;?php</span>
-</span><span id="2" class="l"><a href="#2"> 2: </a><span class="php-comment">/*
-</span></span><span id="3" class="l"><a href="#3"> 3: </a><span class="php-comment"> * To change this license header, choose License Headers in Project Properties.
-</span></span><span id="4" class="l"><a href="#4"> 4: </a><span class="php-comment"> * To change this template file, choose Tools | Templates
-</span></span><span id="5" class="l"><a href="#5"> 5: </a><span class="php-comment"> * and open the template in the editor.
-</span></span><span id="6" class="l"><a href="#6"> 6: </a><span class="php-comment"> */</span>
-</span><span id="7" class="l"><a href="#7"> 7: </a><span class="php-keyword1">namespace</span> DSchoenbauer\Orm\Events\Persistence;
-</span><span id="8" class="l"><a href="#8"> 8: </a>
-</span><span id="9" class="l"><a href="#9"> 9: </a><span class="php-keyword1">use</span> DSchoenbauer\Orm\Events\AbstractEvent;
-</span><span id="10" class="l"><a href="#10">10: </a><span class="php-keyword1">use</span> DSchoenbauer\Orm\Model;
-</span><span id="11" class="l"><a href="#11">11: </a><span class="php-keyword1">use</span> DSchoenbauer\Sql\Command\<span class="php-keyword2">Delete</span>;
-</span><span id="12" class="l"><a href="#12">12: </a><span class="php-keyword1">use</span> DSchoenbauer\Sql\Where\ArrayWhere;
-</span><span id="13" class="l"><a href="#13">13: </a><span class="php-keyword1">use</span> PDO;
-</span><span id="14" class="l"><a href="#14">14: </a><span class="php-keyword1">use</span> Zend\EventManager\Event;
-</span><span id="15" class="l"><a href="#15">15: </a>
-</span><span id="16" class="l"><a href="#16">16: </a><span class="php-comment">/**
-</span></span><span id="17" class="l"><a href="#17">17: </a><span class="php-comment"> * Event driven hook to delete information from a PDO connection
-</span></span><span id="18" class="l"><a href="#18">18: </a><span class="php-comment"> *
-</span></span><span id="19" class="l"><a href="#19">19: </a><span class="php-comment"> * @author David Schoenbauer &lt;dschoenbauer@gmail.com&gt;
-</span></span><span id="20" class="l"><a href="#20">20: </a><span class="php-comment"> */</span>
-</span><span id="21" class="l"><a href="#21">21: </a><span class="php-keyword1">class</span> PdoDelete <span class="php-keyword1">extends</span> AbstractEvent
-</span><span id="22" class="l"><a href="#22">22: </a>{
-</span><span id="23" class="l"><a href="#23">23: </a>
-</span><span id="24" class="l"><a href="#24">24: </a>    <span class="php-keyword1">private</span> <span class="php-var">$adapter</span>;
-</span><span id="25" class="l"><a href="#25">25: </a>    <span class="php-keyword1">private</span> <span class="php-var">$delete</span>;
-</span><span id="26" class="l"><a href="#26">26: </a>
-</span><span id="27" class="l"><a href="#27">27: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> __construct(PDO <span class="php-var">$adapter</span>, <span class="php-keyword2">Delete</span> <span class="php-var">$delete</span> = <span class="php-keyword1">null</span>)
-</span><span id="28" class="l"><a href="#28">28: </a>    {
-</span><span id="29" class="l"><a href="#29">29: </a>        <span class="php-var">$this</span>-&gt;setAdapter(<span class="php-var">$adapter</span>)-&gt;setDelete(<span class="php-var">$delete</span>);
-</span><span id="30" class="l"><a href="#30">30: </a>    }
-</span><span id="31" class="l"><a href="#31">31: </a>
-</span><span id="32" class="l"><a href="#32">32: </a>    <span class="php-comment">/**
-</span></span><span id="33" class="l"><a href="#33">33: </a><span class="php-comment">     * event action
-</span></span><span id="34" class="l"><a href="#34">34: </a><span class="php-comment">     * @param Event $event object passed when event is fired
-</span></span><span id="35" class="l"><a href="#35">35: </a><span class="php-comment">     * @return void
-</span></span><span id="36" class="l"><a href="#36">36: </a><span class="php-comment">     * @since v1.0.0
-</span></span><span id="37" class="l"><a href="#37">37: </a><span class="php-comment">     */</span>
-</span><span id="38" class="l"><a href="#38">38: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> onExecute(Event <span class="php-var">$event</span>)
-</span><span id="39" class="l"><a href="#39">39: </a>    {
-</span><span id="40" class="l"><a href="#40">40: </a>        <span class="php-keyword1">if</span> (!<span class="php-var">$event</span>-&gt;getTarget() <span class="php-keyword1">instanceof</span> Model) {
-</span><span id="41" class="l"><a href="#41">41: </a>            <span class="php-keyword1">return</span>;
-</span><span id="42" class="l"><a href="#42">42: </a>        }
-</span><span id="43" class="l"><a href="#43">43: </a>        <span class="php-comment">/* @var $model Model */</span>
-</span><span id="44" class="l"><a href="#44">44: </a>        <span class="php-var">$model</span> = <span class="php-var">$event</span>-&gt;getTarget();
-</span><span id="45" class="l"><a href="#45">45: </a>        <span class="php-var">$entity</span> = <span class="php-var">$model</span>-&gt;getEntity();
-</span><span id="46" class="l"><a href="#46">46: </a>        <span class="php-var">$this</span>-&gt;getDelete()
-</span><span id="47" class="l"><a href="#47">47: </a>            -&gt;setTable(<span class="php-var">$entity</span>-&gt;getTable())
-</span><span id="48" class="l"><a href="#48">48: </a>            -&gt;setWhere(<span class="php-keyword1">new</span> ArrayWhere([<span class="php-var">$entity</span>-&gt;getIdField() =&gt; <span class="php-var">$model</span>-&gt;getId()]))
-</span><span id="49" class="l"><a href="#49">49: </a>            -&gt;execute(<span class="php-var">$this</span>-&gt;getAdapter());
-</span><span id="50" class="l"><a href="#50">50: </a>    }
-</span><span id="51" class="l"><a href="#51">51: </a>    <span class="php-comment">/**
-</span></span><span id="52" class="l"><a href="#52">52: </a><span class="php-comment">     * Returns a PHP Data Object
-</span></span><span id="53" class="l"><a href="#53">53: </a><span class="php-comment">     * @return PDO
-</span></span><span id="54" class="l"><a href="#54">54: </a><span class="php-comment">     * @since v1.0.0
-</span></span><span id="55" class="l"><a href="#55">55: </a><span class="php-comment">     */</span>
-</span><span id="56" class="l"><a href="#56">56: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> getAdapter()
-</span><span id="57" class="l"><a href="#57">57: </a>    {
-</span><span id="58" class="l"><a href="#58">58: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>-&gt;adapter;
-</span><span id="59" class="l"><a href="#59">59: </a>    }
-</span><span id="60" class="l"><a href="#60">60: </a>
-</span><span id="61" class="l"><a href="#61">61: </a>        <span class="php-comment">/**
-</span></span><span id="62" class="l"><a href="#62">62: </a><span class="php-comment">     * PDO connection to a db of some sort.
-</span></span><span id="63" class="l"><a href="#63">63: </a><span class="php-comment">     * @param PDO $adapter
-</span></span><span id="64" class="l"><a href="#64">64: </a><span class="php-comment">     * @return $this
-</span></span><span id="65" class="l"><a href="#65">65: </a><span class="php-comment">     * @since v1.0.0
-</span></span><span id="66" class="l"><a href="#66">66: </a><span class="php-comment">     */</span>
-</span><span id="67" class="l"><a href="#67">67: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> setAdapter(PDO <span class="php-var">$adapter</span>)
-</span><span id="68" class="l"><a href="#68">68: </a>    {
-</span><span id="69" class="l"><a href="#69">69: </a>        <span class="php-var">$this</span>-&gt;adapter = <span class="php-var">$adapter</span>;
-</span><span id="70" class="l"><a href="#70">70: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>;
-</span><span id="71" class="l"><a href="#71">71: </a>    }
-</span><span id="72" class="l"><a href="#72">72: </a>
-</span><span id="73" class="l"><a href="#73">73: </a>    <span class="php-comment">/**
-</span></span><span id="74" class="l"><a href="#74">74: </a><span class="php-comment">     * object with logic for the delete. If Delete is not provided one will be lazy loaded
-</span></span><span id="75" class="l"><a href="#75">75: </a><span class="php-comment">     * @return Delete
-</span></span><span id="76" class="l"><a href="#76">76: </a><span class="php-comment">     * @since v1.0.0
-</span></span><span id="77" class="l"><a href="#77">77: </a><span class="php-comment">     */</span>
-</span><span id="78" class="l"><a href="#78">78: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> getDelete()
-</span><span id="79" class="l"><a href="#79">79: </a>    {
-</span><span id="80" class="l"><a href="#80">80: </a>        <span class="php-keyword1">if</span> (!<span class="php-var">$this</span>-&gt;<span class="php-keyword2">delete</span>) {
-</span><span id="81" class="l"><a href="#81">81: </a>            <span class="php-var">$this</span>-&gt;setDelete(<span class="php-keyword1">new</span> <span class="php-keyword2">Delete</span>(<span class="php-keyword1">null</span>));
-</span><span id="82" class="l"><a href="#82">82: </a>        }
-</span><span id="83" class="l"><a href="#83">83: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>-&gt;<span class="php-keyword2">delete</span>;
-</span><span id="84" class="l"><a href="#84">84: </a>    }
-</span><span id="85" class="l"><a href="#85">85: </a>
-</span><span id="86" class="l"><a href="#86">86: </a>    <span class="php-comment">/**
-</span></span><span id="87" class="l"><a href="#87">87: </a><span class="php-comment">     * Object that contains the delete logic
-</span></span><span id="88" class="l"><a href="#88">88: </a><span class="php-comment">     * @param Delete $delete
-</span></span><span id="89" class="l"><a href="#89">89: </a><span class="php-comment">     * @return $this
-</span></span><span id="90" class="l"><a href="#90">90: </a><span class="php-comment">     * @since v1.0.0
-</span></span><span id="91" class="l"><a href="#91">91: </a><span class="php-comment">     */</span>
-</span><span id="92" class="l"><a href="#92">92: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> setDelete(<span class="php-keyword2">Delete</span> <span class="php-var">$delete</span> = <span class="php-keyword1">null</span>)
-</span><span id="93" class="l"><a href="#93">93: </a>    {
-</span><span id="94" class="l"><a href="#94">94: </a>        <span class="php-var">$this</span>-&gt;<span class="php-keyword2">delete</span> = <span class="php-var">$delete</span>;
-</span><span id="95" class="l"><a href="#95">95: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>;
-</span><span id="96" class="l"><a href="#96">96: </a>    }
-</span><span id="97" class="l"><a href="#97">97: </a>}
-</span><span id="98" class="l"><a href="#98">98: </a></span></code></pre>
+<pre><code><span id="1" class="l"><a href="#1">  1: </a><span class="xlang">&lt;?php</span>
+</span><span id="2" class="l"><a href="#2">  2: </a><span class="php-comment">/*
+</span></span><span id="3" class="l"><a href="#3">  3: </a><span class="php-comment"> * To change this license header, choose License Headers in Project Properties.
+</span></span><span id="4" class="l"><a href="#4">  4: </a><span class="php-comment"> * To change this template file, choose Tools | Templates
+</span></span><span id="5" class="l"><a href="#5">  5: </a><span class="php-comment"> * and open the template in the editor.
+</span></span><span id="6" class="l"><a href="#6">  6: </a><span class="php-comment"> */</span>
+</span><span id="7" class="l"><a href="#7">  7: </a><span class="php-keyword1">namespace</span> DSchoenbauer\Orm\Events\Persistence;
+</span><span id="8" class="l"><a href="#8">  8: </a>
+</span><span id="9" class="l"><a href="#9">  9: </a><span class="php-keyword1">use</span> DSchoenbauer\Orm\Events\AbstractEvent;
+</span><span id="10" class="l"><a href="#10"> 10: </a><span class="php-keyword1">use</span> DSchoenbauer\Orm\Model;
+</span><span id="11" class="l"><a href="#11"> 11: </a><span class="php-keyword1">use</span> DSchoenbauer\Sql\Command\<span class="php-keyword2">Delete</span>;
+</span><span id="12" class="l"><a href="#12"> 12: </a><span class="php-keyword1">use</span> DSchoenbauer\Sql\Where\ArrayWhere;
+</span><span id="13" class="l"><a href="#13"> 13: </a><span class="php-keyword1">use</span> PDO;
+</span><span id="14" class="l"><a href="#14"> 14: </a><span class="php-keyword1">use</span> Zend\EventManager\Event;
+</span><span id="15" class="l"><a href="#15"> 15: </a>
+</span><span id="16" class="l"><a href="#16"> 16: </a><span class="php-comment">/**
+</span></span><span id="17" class="l"><a href="#17"> 17: </a><span class="php-comment"> * Event driven hook to delete information from a PDO connection
+</span></span><span id="18" class="l"><a href="#18"> 18: </a><span class="php-comment"> *
+</span></span><span id="19" class="l"><a href="#19"> 19: </a><span class="php-comment"> * @author David Schoenbauer &lt;dschoenbauer@gmail.com&gt;
+</span></span><span id="20" class="l"><a href="#20"> 20: </a><span class="php-comment"> */</span>
+</span><span id="21" class="l"><a href="#21"> 21: </a><span class="php-keyword1">class</span> PdoDelete <span class="php-keyword1">extends</span> AbstractEvent
+</span><span id="22" class="l"><a href="#22"> 22: </a>{
+</span><span id="23" class="l"><a href="#23"> 23: </a>
+</span><span id="24" class="l"><a href="#24"> 24: </a>    <span class="php-keyword1">private</span> <span class="php-var">$adapter</span>;
+</span><span id="25" class="l"><a href="#25"> 25: </a>    <span class="php-keyword1">private</span> <span class="php-var">$delete</span>;
+</span><span id="26" class="l"><a href="#26"> 26: </a>
+</span><span id="27" class="l"><a href="#27"> 27: </a>    <span class="php-comment">/**
+</span></span><span id="28" class="l"><a href="#28"> 28: </a><span class="php-comment">     * @param array $events An array of event names to bind to
+</span></span><span id="29" class="l"><a href="#29"> 29: </a><span class="php-comment">     * @param PDO $adapter
+</span></span><span id="30" class="l"><a href="#30"> 30: </a><span class="php-comment">     * @param Delete $delete
+</span></span><span id="31" class="l"><a href="#31"> 31: </a><span class="php-comment">     */</span>
+</span><span id="32" class="l"><a href="#32"> 32: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> __construct(<span class="php-keyword1">array</span> <span class="php-var">$events</span>, PDO <span class="php-var">$adapter</span>, <span class="php-keyword2">Delete</span> <span class="php-var">$delete</span> = <span class="php-keyword1">null</span>)
+</span><span id="33" class="l"><a href="#33"> 33: </a>    {
+</span><span id="34" class="l"><a href="#34"> 34: </a>        parent::__construct(<span class="php-var">$events</span>);
+</span><span id="35" class="l"><a href="#35"> 35: </a>        <span class="php-var">$this</span>-&gt;setAdapter(<span class="php-var">$adapter</span>)-&gt;setDelete(<span class="php-var">$delete</span>);
+</span><span id="36" class="l"><a href="#36"> 36: </a>    }
+</span><span id="37" class="l"><a href="#37"> 37: </a>
+</span><span id="38" class="l"><a href="#38"> 38: </a>    <span class="php-comment">/**
+</span></span><span id="39" class="l"><a href="#39"> 39: </a><span class="php-comment">     * event action
+</span></span><span id="40" class="l"><a href="#40"> 40: </a><span class="php-comment">     * @param Event $event object passed when event is fired
+</span></span><span id="41" class="l"><a href="#41"> 41: </a><span class="php-comment">     * @return void
+</span></span><span id="42" class="l"><a href="#42"> 42: </a><span class="php-comment">     * @since v1.0.0
+</span></span><span id="43" class="l"><a href="#43"> 43: </a><span class="php-comment">     */</span>
+</span><span id="44" class="l"><a href="#44"> 44: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> onExecute(Event <span class="php-var">$event</span>)
+</span><span id="45" class="l"><a href="#45"> 45: </a>    {
+</span><span id="46" class="l"><a href="#46"> 46: </a>        <span class="php-keyword1">if</span> (!<span class="php-var">$event</span>-&gt;getTarget() <span class="php-keyword1">instanceof</span> Model) {
+</span><span id="47" class="l"><a href="#47"> 47: </a>            <span class="php-keyword1">return</span>;
+</span><span id="48" class="l"><a href="#48"> 48: </a>        }
+</span><span id="49" class="l"><a href="#49"> 49: </a>        <span class="php-comment">/* @var $model Model */</span>
+</span><span id="50" class="l"><a href="#50"> 50: </a>        <span class="php-var">$model</span> = <span class="php-var">$event</span>-&gt;getTarget();
+</span><span id="51" class="l"><a href="#51"> 51: </a>        <span class="php-var">$entity</span> = <span class="php-var">$model</span>-&gt;getEntity();
+</span><span id="52" class="l"><a href="#52"> 52: </a>        <span class="php-var">$this</span>-&gt;getDelete()
+</span><span id="53" class="l"><a href="#53"> 53: </a>            -&gt;setTable(<span class="php-var">$entity</span>-&gt;getTable())
+</span><span id="54" class="l"><a href="#54"> 54: </a>            -&gt;setWhere(<span class="php-keyword1">new</span> ArrayWhere([<span class="php-var">$entity</span>-&gt;getIdField() =&gt; <span class="php-var">$model</span>-&gt;getId()]))
+</span><span id="55" class="l"><a href="#55"> 55: </a>            -&gt;execute(<span class="php-var">$this</span>-&gt;getAdapter());
+</span><span id="56" class="l"><a href="#56"> 56: </a>    }
+</span><span id="57" class="l"><a href="#57"> 57: </a>    <span class="php-comment">/**
+</span></span><span id="58" class="l"><a href="#58"> 58: </a><span class="php-comment">     * Returns a PHP Data Object
+</span></span><span id="59" class="l"><a href="#59"> 59: </a><span class="php-comment">     * @return PDO
+</span></span><span id="60" class="l"><a href="#60"> 60: </a><span class="php-comment">     * @since v1.0.0
+</span></span><span id="61" class="l"><a href="#61"> 61: </a><span class="php-comment">     */</span>
+</span><span id="62" class="l"><a href="#62"> 62: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> getAdapter()
+</span><span id="63" class="l"><a href="#63"> 63: </a>    {
+</span><span id="64" class="l"><a href="#64"> 64: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>-&gt;adapter;
+</span><span id="65" class="l"><a href="#65"> 65: </a>    }
+</span><span id="66" class="l"><a href="#66"> 66: </a>
+</span><span id="67" class="l"><a href="#67"> 67: </a>        <span class="php-comment">/**
+</span></span><span id="68" class="l"><a href="#68"> 68: </a><span class="php-comment">     * PDO connection to a db of some sort.
+</span></span><span id="69" class="l"><a href="#69"> 69: </a><span class="php-comment">     * @param PDO $adapter
+</span></span><span id="70" class="l"><a href="#70"> 70: </a><span class="php-comment">     * @return $this
+</span></span><span id="71" class="l"><a href="#71"> 71: </a><span class="php-comment">     * @since v1.0.0
+</span></span><span id="72" class="l"><a href="#72"> 72: </a><span class="php-comment">     */</span>
+</span><span id="73" class="l"><a href="#73"> 73: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> setAdapter(PDO <span class="php-var">$adapter</span>)
+</span><span id="74" class="l"><a href="#74"> 74: </a>    {
+</span><span id="75" class="l"><a href="#75"> 75: </a>        <span class="php-var">$this</span>-&gt;adapter = <span class="php-var">$adapter</span>;
+</span><span id="76" class="l"><a href="#76"> 76: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>;
+</span><span id="77" class="l"><a href="#77"> 77: </a>    }
+</span><span id="78" class="l"><a href="#78"> 78: </a>
+</span><span id="79" class="l"><a href="#79"> 79: </a>    <span class="php-comment">/**
+</span></span><span id="80" class="l"><a href="#80"> 80: </a><span class="php-comment">     * object with logic for the delete. If Delete is not provided one will be lazy loaded
+</span></span><span id="81" class="l"><a href="#81"> 81: </a><span class="php-comment">     * @return Delete
+</span></span><span id="82" class="l"><a href="#82"> 82: </a><span class="php-comment">     * @since v1.0.0
+</span></span><span id="83" class="l"><a href="#83"> 83: </a><span class="php-comment">     */</span>
+</span><span id="84" class="l"><a href="#84"> 84: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> getDelete()
+</span><span id="85" class="l"><a href="#85"> 85: </a>    {
+</span><span id="86" class="l"><a href="#86"> 86: </a>        <span class="php-keyword1">if</span> (!<span class="php-var">$this</span>-&gt;<span class="php-keyword2">delete</span>) {
+</span><span id="87" class="l"><a href="#87"> 87: </a>            <span class="php-var">$this</span>-&gt;setDelete(<span class="php-keyword1">new</span> <span class="php-keyword2">Delete</span>(<span class="php-keyword1">null</span>));
+</span><span id="88" class="l"><a href="#88"> 88: </a>        }
+</span><span id="89" class="l"><a href="#89"> 89: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>-&gt;<span class="php-keyword2">delete</span>;
+</span><span id="90" class="l"><a href="#90"> 90: </a>    }
+</span><span id="91" class="l"><a href="#91"> 91: </a>
+</span><span id="92" class="l"><a href="#92"> 92: </a>    <span class="php-comment">/**
+</span></span><span id="93" class="l"><a href="#93"> 93: </a><span class="php-comment">     * Object that contains the delete logic
+</span></span><span id="94" class="l"><a href="#94"> 94: </a><span class="php-comment">     * @param Delete $delete
+</span></span><span id="95" class="l"><a href="#95"> 95: </a><span class="php-comment">     * @return $this
+</span></span><span id="96" class="l"><a href="#96"> 96: </a><span class="php-comment">     * @since v1.0.0
+</span></span><span id="97" class="l"><a href="#97"> 97: </a><span class="php-comment">     */</span>
+</span><span id="98" class="l"><a href="#98"> 98: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> setDelete(<span class="php-keyword2">Delete</span> <span class="php-var">$delete</span> = <span class="php-keyword1">null</span>)
+</span><span id="99" class="l"><a href="#99"> 99: </a>    {
+</span><span id="100" class="l"><a href="#100">100: </a>        <span class="php-var">$this</span>-&gt;<span class="php-keyword2">delete</span> = <span class="php-var">$delete</span>;
+</span><span id="101" class="l"><a href="#101">101: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>;
+</span><span id="102" class="l"><a href="#102">102: </a>    }
+</span><span id="103" class="l"><a href="#103">103: </a>}
+</span><span id="104" class="l"><a href="#104">104: </a></span></code></pre>
 
 	<div id="footer">
 		 API documentation generated by <a href="http://apigen.org">ApiGen</a>

--- a/docs/source-class-DSchoenbauer.Orm.Events.Persistence.PdoSelect.html
+++ b/docs/source-class-DSchoenbauer.Orm.Events.Persistence.PdoSelect.html
@@ -208,84 +208,89 @@
 </span><span id="43" class="l"><a href="#43"> 43: </a>    <span class="php-keyword1">private</span> <span class="php-var">$adapter</span>;
 </span><span id="44" class="l"><a href="#44"> 44: </a>    <span class="php-keyword1">private</span> <span class="php-var">$select</span>;
 </span><span id="45" class="l"><a href="#45"> 45: </a>
-</span><span id="46" class="l"><a href="#46"> 46: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> __construct(\PDO <span class="php-var">$adapter</span>, Select <span class="php-var">$select</span> = <span class="php-keyword1">null</span>)
-</span><span id="47" class="l"><a href="#47"> 47: </a>    {
-</span><span id="48" class="l"><a href="#48"> 48: </a>        <span class="php-var">$this</span>-&gt;setEvents([ModelEvents::FETCH])
-</span><span id="49" class="l"><a href="#49"> 49: </a>            -&gt;setAdapter(<span class="php-var">$adapter</span>)
-</span><span id="50" class="l"><a href="#50"> 50: </a>            -&gt;setSelect(<span class="php-var">$select</span>);
-</span><span id="51" class="l"><a href="#51"> 51: </a>    }
-</span><span id="52" class="l"><a href="#52"> 52: </a>
-</span><span id="53" class="l"><a href="#53"> 53: </a>    <span class="php-comment">/**
-</span></span><span id="54" class="l"><a href="#54"> 54: </a><span class="php-comment">     * event action
-</span></span><span id="55" class="l"><a href="#55"> 55: </a><span class="php-comment">     * @param Event $event object passed when event is fired
-</span></span><span id="56" class="l"><a href="#56"> 56: </a><span class="php-comment">     * @return void
-</span></span><span id="57" class="l"><a href="#57"> 57: </a><span class="php-comment">     * @since v1.0.0
-</span></span><span id="58" class="l"><a href="#58"> 58: </a><span class="php-comment">     */</span>
-</span><span id="59" class="l"><a href="#59"> 59: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> onExecute(Event <span class="php-var">$event</span>)
-</span><span id="60" class="l"><a href="#60"> 60: </a>    {
-</span><span id="61" class="l"><a href="#61"> 61: </a>        <span class="php-keyword1">if</span> (!<span class="php-var">$event</span>-&gt;getTarget() <span class="php-keyword1">instanceof</span> Model) {
-</span><span id="62" class="l"><a href="#62"> 62: </a>            <span class="php-keyword1">return</span>; <span class="php-comment">//Nothing to do with this event</span>
-</span><span id="63" class="l"><a href="#63"> 63: </a>        }
-</span><span id="64" class="l"><a href="#64"> 64: </a>        <span class="php-comment">/* @var $model Model */</span>
-</span><span id="65" class="l"><a href="#65"> 65: </a>        <span class="php-var">$model</span> = <span class="php-var">$event</span>-&gt;getTarget();
-</span><span id="66" class="l"><a href="#66"> 66: </a>        <span class="php-var">$entity</span> = <span class="php-var">$model</span>-&gt;getEntity();
-</span><span id="67" class="l"><a href="#67"> 67: </a>        <span class="php-var">$model</span>-&gt;setData(
-</span><span id="68" class="l"><a href="#68"> 68: </a>            <span class="php-var">$this</span>-&gt;getSelect()
-</span><span id="69" class="l"><a href="#69"> 69: </a>                -&gt;setTable(<span class="php-var">$entity</span>-&gt;getTable())
-</span><span id="70" class="l"><a href="#70"> 70: </a>                -&gt;setFields(<span class="php-var">$entity</span>-&gt;getAllFields())
-</span><span id="71" class="l"><a href="#71"> 71: </a>                -&gt;setWhere(<span class="php-keyword1">new</span> ArrayWhere([<span class="php-var">$entity</span>-&gt;getIdField() =&gt; <span class="php-var">$model</span>-&gt;getId()]))-&gt;setFetchFlat()
-</span><span id="72" class="l"><a href="#72"> 72: </a>                -&gt;execute(<span class="php-var">$this</span>-&gt;getAdapter())
-</span><span id="73" class="l"><a href="#73"> 73: </a>        );
-</span><span id="74" class="l"><a href="#74"> 74: </a>    }
-</span><span id="75" class="l"><a href="#75"> 75: </a>
-</span><span id="76" class="l"><a href="#76"> 76: </a>    <span class="php-comment">/**
-</span></span><span id="77" class="l"><a href="#77"> 77: </a><span class="php-comment">     * Returns a PHP Data Object
-</span></span><span id="78" class="l"><a href="#78"> 78: </a><span class="php-comment">     * @return PDO
-</span></span><span id="79" class="l"><a href="#79"> 79: </a><span class="php-comment">     * @since v1.0.0
-</span></span><span id="80" class="l"><a href="#80"> 80: </a><span class="php-comment">     */</span>
-</span><span id="81" class="l"><a href="#81"> 81: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> getAdapter()
-</span><span id="82" class="l"><a href="#82"> 82: </a>    {
-</span><span id="83" class="l"><a href="#83"> 83: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>-&gt;adapter;
-</span><span id="84" class="l"><a href="#84"> 84: </a>    }
-</span><span id="85" class="l"><a href="#85"> 85: </a>
-</span><span id="86" class="l"><a href="#86"> 86: </a>    <span class="php-comment">/**
-</span></span><span id="87" class="l"><a href="#87"> 87: </a><span class="php-comment">     * PDO connection to a db of some sort.
-</span></span><span id="88" class="l"><a href="#88"> 88: </a><span class="php-comment">     * @param PDO $adapter
-</span></span><span id="89" class="l"><a href="#89"> 89: </a><span class="php-comment">     * @return $this
-</span></span><span id="90" class="l"><a href="#90"> 90: </a><span class="php-comment">     * @since v1.0.0
-</span></span><span id="91" class="l"><a href="#91"> 91: </a><span class="php-comment">     */</span>
-</span><span id="92" class="l"><a href="#92"> 92: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> setAdapter(PDO <span class="php-var">$adapter</span>)
-</span><span id="93" class="l"><a href="#93"> 93: </a>    {
-</span><span id="94" class="l"><a href="#94"> 94: </a>        <span class="php-var">$this</span>-&gt;adapter = <span class="php-var">$adapter</span>;
-</span><span id="95" class="l"><a href="#95"> 95: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>;
-</span><span id="96" class="l"><a href="#96"> 96: </a>    }
-</span><span id="97" class="l"><a href="#97"> 97: </a>
-</span><span id="98" class="l"><a href="#98"> 98: </a>    <span class="php-comment">/**
-</span></span><span id="99" class="l"><a href="#99"> 99: </a><span class="php-comment">     * object with logic for the Select. If Select is not provided one will be lazy loaded
-</span></span><span id="100" class="l"><a href="#100">100: </a><span class="php-comment">     * @return Select
-</span></span><span id="101" class="l"><a href="#101">101: </a><span class="php-comment">     * @since v1.0.0
-</span></span><span id="102" class="l"><a href="#102">102: </a><span class="php-comment">     */</span>
-</span><span id="103" class="l"><a href="#103">103: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> getSelect()
-</span><span id="104" class="l"><a href="#104">104: </a>    {
-</span><span id="105" class="l"><a href="#105">105: </a>        <span class="php-keyword1">if</span> (!<span class="php-var">$this</span>-&gt;select <span class="php-keyword1">instanceof</span> Select) {
-</span><span id="106" class="l"><a href="#106">106: </a>            <span class="php-var">$this</span>-&gt;select = <span class="php-keyword1">new</span> Select(<span class="php-quote">&quot;&quot;</span>);
-</span><span id="107" class="l"><a href="#107">107: </a>        }
-</span><span id="108" class="l"><a href="#108">108: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>-&gt;select;
-</span><span id="109" class="l"><a href="#109">109: </a>    }
-</span><span id="110" class="l"><a href="#110">110: </a>
-</span><span id="111" class="l"><a href="#111">111: </a>    <span class="php-comment">/**
-</span></span><span id="112" class="l"><a href="#112">112: </a><span class="php-comment">     * Object that contains the select logic
-</span></span><span id="113" class="l"><a href="#113">113: </a><span class="php-comment">     * @param Select $select
-</span></span><span id="114" class="l"><a href="#114">114: </a><span class="php-comment">     * @return $this
-</span></span><span id="115" class="l"><a href="#115">115: </a><span class="php-comment">     * @since v1.0.0
-</span></span><span id="116" class="l"><a href="#116">116: </a><span class="php-comment">     */</span>
-</span><span id="117" class="l"><a href="#117">117: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> setSelect(Select <span class="php-var">$select</span> = <span class="php-keyword1">null</span>)
-</span><span id="118" class="l"><a href="#118">118: </a>    {
-</span><span id="119" class="l"><a href="#119">119: </a>        <span class="php-var">$this</span>-&gt;select = <span class="php-var">$select</span>;
-</span><span id="120" class="l"><a href="#120">120: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>;
-</span><span id="121" class="l"><a href="#121">121: </a>    }
-</span><span id="122" class="l"><a href="#122">122: </a>}
-</span><span id="123" class="l"><a href="#123">123: </a></span></code></pre>
+</span><span id="46" class="l"><a href="#46"> 46: </a>    <span class="php-comment">/**
+</span></span><span id="47" class="l"><a href="#47"> 47: </a><span class="php-comment">     * @param array $events An array of event names to bind to
+</span></span><span id="48" class="l"><a href="#48"> 48: </a><span class="php-comment">     * @param PDO $adapter
+</span></span><span id="49" class="l"><a href="#49"> 49: </a><span class="php-comment">     * @param Select $select
+</span></span><span id="50" class="l"><a href="#50"> 50: </a><span class="php-comment">     */</span>
+</span><span id="51" class="l"><a href="#51"> 51: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> __construct(<span class="php-keyword1">array</span> <span class="php-var">$events</span>, \PDO <span class="php-var">$adapter</span>, Select <span class="php-var">$select</span> = <span class="php-keyword1">null</span>)
+</span><span id="52" class="l"><a href="#52"> 52: </a>    {
+</span><span id="53" class="l"><a href="#53"> 53: </a>        parent::__construct(<span class="php-var">$events</span>);
+</span><span id="54" class="l"><a href="#54"> 54: </a>        <span class="php-var">$this</span>-&gt;setAdapter(<span class="php-var">$adapter</span>)
+</span><span id="55" class="l"><a href="#55"> 55: </a>            -&gt;setSelect(<span class="php-var">$select</span>);
+</span><span id="56" class="l"><a href="#56"> 56: </a>    }
+</span><span id="57" class="l"><a href="#57"> 57: </a>
+</span><span id="58" class="l"><a href="#58"> 58: </a>    <span class="php-comment">/**
+</span></span><span id="59" class="l"><a href="#59"> 59: </a><span class="php-comment">     * event action
+</span></span><span id="60" class="l"><a href="#60"> 60: </a><span class="php-comment">     * @param Event $event object passed when event is fired
+</span></span><span id="61" class="l"><a href="#61"> 61: </a><span class="php-comment">     * @return void
+</span></span><span id="62" class="l"><a href="#62"> 62: </a><span class="php-comment">     * @since v1.0.0
+</span></span><span id="63" class="l"><a href="#63"> 63: </a><span class="php-comment">     */</span>
+</span><span id="64" class="l"><a href="#64"> 64: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> onExecute(Event <span class="php-var">$event</span>)
+</span><span id="65" class="l"><a href="#65"> 65: </a>    {
+</span><span id="66" class="l"><a href="#66"> 66: </a>        <span class="php-keyword1">if</span> (!<span class="php-var">$event</span>-&gt;getTarget() <span class="php-keyword1">instanceof</span> Model) {
+</span><span id="67" class="l"><a href="#67"> 67: </a>            <span class="php-keyword1">return</span>; <span class="php-comment">//Nothing to do with this event</span>
+</span><span id="68" class="l"><a href="#68"> 68: </a>        }
+</span><span id="69" class="l"><a href="#69"> 69: </a>        <span class="php-comment">/* @var $model Model */</span>
+</span><span id="70" class="l"><a href="#70"> 70: </a>        <span class="php-var">$model</span> = <span class="php-var">$event</span>-&gt;getTarget();
+</span><span id="71" class="l"><a href="#71"> 71: </a>        <span class="php-var">$entity</span> = <span class="php-var">$model</span>-&gt;getEntity();
+</span><span id="72" class="l"><a href="#72"> 72: </a>        <span class="php-var">$model</span>-&gt;setData(
+</span><span id="73" class="l"><a href="#73"> 73: </a>            <span class="php-var">$this</span>-&gt;getSelect()
+</span><span id="74" class="l"><a href="#74"> 74: </a>                -&gt;setTable(<span class="php-var">$entity</span>-&gt;getTable())
+</span><span id="75" class="l"><a href="#75"> 75: </a>                -&gt;setFields(<span class="php-var">$entity</span>-&gt;getAllFields())
+</span><span id="76" class="l"><a href="#76"> 76: </a>                -&gt;setWhere(<span class="php-keyword1">new</span> ArrayWhere([<span class="php-var">$entity</span>-&gt;getIdField() =&gt; <span class="php-var">$model</span>-&gt;getId()]))-&gt;setFetchFlat()
+</span><span id="77" class="l"><a href="#77"> 77: </a>                -&gt;execute(<span class="php-var">$this</span>-&gt;getAdapter())
+</span><span id="78" class="l"><a href="#78"> 78: </a>        );
+</span><span id="79" class="l"><a href="#79"> 79: </a>    }
+</span><span id="80" class="l"><a href="#80"> 80: </a>
+</span><span id="81" class="l"><a href="#81"> 81: </a>    <span class="php-comment">/**
+</span></span><span id="82" class="l"><a href="#82"> 82: </a><span class="php-comment">     * Returns a PHP Data Object
+</span></span><span id="83" class="l"><a href="#83"> 83: </a><span class="php-comment">     * @return PDO
+</span></span><span id="84" class="l"><a href="#84"> 84: </a><span class="php-comment">     * @since v1.0.0
+</span></span><span id="85" class="l"><a href="#85"> 85: </a><span class="php-comment">     */</span>
+</span><span id="86" class="l"><a href="#86"> 86: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> getAdapter()
+</span><span id="87" class="l"><a href="#87"> 87: </a>    {
+</span><span id="88" class="l"><a href="#88"> 88: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>-&gt;adapter;
+</span><span id="89" class="l"><a href="#89"> 89: </a>    }
+</span><span id="90" class="l"><a href="#90"> 90: </a>
+</span><span id="91" class="l"><a href="#91"> 91: </a>    <span class="php-comment">/**
+</span></span><span id="92" class="l"><a href="#92"> 92: </a><span class="php-comment">     * PDO connection to a db of some sort.
+</span></span><span id="93" class="l"><a href="#93"> 93: </a><span class="php-comment">     * @param PDO $adapter
+</span></span><span id="94" class="l"><a href="#94"> 94: </a><span class="php-comment">     * @return $this
+</span></span><span id="95" class="l"><a href="#95"> 95: </a><span class="php-comment">     * @since v1.0.0
+</span></span><span id="96" class="l"><a href="#96"> 96: </a><span class="php-comment">     */</span>
+</span><span id="97" class="l"><a href="#97"> 97: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> setAdapter(PDO <span class="php-var">$adapter</span>)
+</span><span id="98" class="l"><a href="#98"> 98: </a>    {
+</span><span id="99" class="l"><a href="#99"> 99: </a>        <span class="php-var">$this</span>-&gt;adapter = <span class="php-var">$adapter</span>;
+</span><span id="100" class="l"><a href="#100">100: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>;
+</span><span id="101" class="l"><a href="#101">101: </a>    }
+</span><span id="102" class="l"><a href="#102">102: </a>
+</span><span id="103" class="l"><a href="#103">103: </a>    <span class="php-comment">/**
+</span></span><span id="104" class="l"><a href="#104">104: </a><span class="php-comment">     * object with logic for the Select. If Select is not provided one will be lazy loaded
+</span></span><span id="105" class="l"><a href="#105">105: </a><span class="php-comment">     * @return Select
+</span></span><span id="106" class="l"><a href="#106">106: </a><span class="php-comment">     * @since v1.0.0
+</span></span><span id="107" class="l"><a href="#107">107: </a><span class="php-comment">     */</span>
+</span><span id="108" class="l"><a href="#108">108: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> getSelect()
+</span><span id="109" class="l"><a href="#109">109: </a>    {
+</span><span id="110" class="l"><a href="#110">110: </a>        <span class="php-keyword1">if</span> (!<span class="php-var">$this</span>-&gt;select <span class="php-keyword1">instanceof</span> Select) {
+</span><span id="111" class="l"><a href="#111">111: </a>            <span class="php-var">$this</span>-&gt;select = <span class="php-keyword1">new</span> Select(<span class="php-quote">&quot;&quot;</span>);
+</span><span id="112" class="l"><a href="#112">112: </a>        }
+</span><span id="113" class="l"><a href="#113">113: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>-&gt;select;
+</span><span id="114" class="l"><a href="#114">114: </a>    }
+</span><span id="115" class="l"><a href="#115">115: </a>
+</span><span id="116" class="l"><a href="#116">116: </a>    <span class="php-comment">/**
+</span></span><span id="117" class="l"><a href="#117">117: </a><span class="php-comment">     * Object that contains the select logic
+</span></span><span id="118" class="l"><a href="#118">118: </a><span class="php-comment">     * @param Select $select
+</span></span><span id="119" class="l"><a href="#119">119: </a><span class="php-comment">     * @return $this
+</span></span><span id="120" class="l"><a href="#120">120: </a><span class="php-comment">     * @since v1.0.0
+</span></span><span id="121" class="l"><a href="#121">121: </a><span class="php-comment">     */</span>
+</span><span id="122" class="l"><a href="#122">122: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> setSelect(Select <span class="php-var">$select</span> = <span class="php-keyword1">null</span>)
+</span><span id="123" class="l"><a href="#123">123: </a>    {
+</span><span id="124" class="l"><a href="#124">124: </a>        <span class="php-var">$this</span>-&gt;select = <span class="php-var">$select</span>;
+</span><span id="125" class="l"><a href="#125">125: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>;
+</span><span id="126" class="l"><a href="#126">126: </a>    }
+</span><span id="127" class="l"><a href="#127">127: </a>}
+</span><span id="128" class="l"><a href="#128">128: </a></span></code></pre>
 
 	<div id="footer">
 		 API documentation generated by <a href="http://apigen.org">ApiGen</a>

--- a/docs/source-class-DSchoenbauer.Orm.Events.Persistence.PdoUpdate.html
+++ b/docs/source-class-DSchoenbauer.Orm.Events.Persistence.PdoUpdate.html
@@ -163,105 +163,111 @@
 		</ul>
 	</div>
 
-<pre><code><span id="1" class="l"><a href="#1"> 1: </a><span class="xlang">&lt;?php</span>
-</span><span id="2" class="l"><a href="#2"> 2: </a><span class="php-comment">/*
-</span></span><span id="3" class="l"><a href="#3"> 3: </a><span class="php-comment"> * To change this license header, choose License Headers in Project Properties.
-</span></span><span id="4" class="l"><a href="#4"> 4: </a><span class="php-comment"> * To change this template file, choose Tools | Templates
-</span></span><span id="5" class="l"><a href="#5"> 5: </a><span class="php-comment"> * and open the template in the editor.
-</span></span><span id="6" class="l"><a href="#6"> 6: </a><span class="php-comment"> */</span>
-</span><span id="7" class="l"><a href="#7"> 7: </a><span class="php-keyword1">namespace</span> DSchoenbauer\Orm\Events\Persistence;
-</span><span id="8" class="l"><a href="#8"> 8: </a>
-</span><span id="9" class="l"><a href="#9"> 9: </a><span class="php-keyword1">use</span> DSchoenbauer\Orm\Events\AbstractEvent;
-</span><span id="10" class="l"><a href="#10">10: </a><span class="php-keyword1">use</span> DSchoenbauer\Orm\Model;
-</span><span id="11" class="l"><a href="#11">11: </a><span class="php-keyword1">use</span> DSchoenbauer\Sql\Command\Update;
-</span><span id="12" class="l"><a href="#12">12: </a><span class="php-keyword1">use</span> DSchoenbauer\Sql\Where\ArrayWhere;
-</span><span id="13" class="l"><a href="#13">13: </a><span class="php-keyword1">use</span> PDO;
-</span><span id="14" class="l"><a href="#14">14: </a><span class="php-keyword1">use</span> Zend\EventManager\Event;
-</span><span id="15" class="l"><a href="#15">15: </a>
-</span><span id="16" class="l"><a href="#16">16: </a><span class="php-comment">/**
-</span></span><span id="17" class="l"><a href="#17">17: </a><span class="php-comment"> * Event driven hook to update information from a PDO connection
-</span></span><span id="18" class="l"><a href="#18">18: </a><span class="php-comment"> *
-</span></span><span id="19" class="l"><a href="#19">19: </a><span class="php-comment"> * @author David Schoenbauer &lt;dschoenbauer@gmail.com&gt;
-</span></span><span id="20" class="l"><a href="#20">20: </a><span class="php-comment"> */</span>
-</span><span id="21" class="l"><a href="#21">21: </a><span class="php-keyword1">class</span> PdoUpdate <span class="php-keyword1">extends</span> AbstractEvent
-</span><span id="22" class="l"><a href="#22">22: </a>{
-</span><span id="23" class="l"><a href="#23">23: </a>
-</span><span id="24" class="l"><a href="#24">24: </a>    <span class="php-keyword1">private</span> <span class="php-var">$adapter</span>;
-</span><span id="25" class="l"><a href="#25">25: </a>    <span class="php-keyword1">private</span> <span class="php-var">$update</span>;
-</span><span id="26" class="l"><a href="#26">26: </a>
-</span><span id="27" class="l"><a href="#27">27: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> __construct(PDO <span class="php-var">$adapter</span>, Update <span class="php-var">$update</span> = <span class="php-keyword1">null</span>)
-</span><span id="28" class="l"><a href="#28">28: </a>    {
-</span><span id="29" class="l"><a href="#29">29: </a>        <span class="php-var">$this</span>-&gt;setAdapter(<span class="php-var">$adapter</span>)-&gt;setUpdate(<span class="php-var">$update</span>);
-</span><span id="30" class="l"><a href="#30">30: </a>    }
-</span><span id="31" class="l"><a href="#31">31: </a>
-</span><span id="32" class="l"><a href="#32">32: </a>    <span class="php-comment">/**
-</span></span><span id="33" class="l"><a href="#33">33: </a><span class="php-comment">     * event action
-</span></span><span id="34" class="l"><a href="#34">34: </a><span class="php-comment">     * @param Event $event object passed when event is fired
-</span></span><span id="35" class="l"><a href="#35">35: </a><span class="php-comment">     * @return void
-</span></span><span id="36" class="l"><a href="#36">36: </a><span class="php-comment">     * @since v1.0.0
-</span></span><span id="37" class="l"><a href="#37">37: </a><span class="php-comment">     */</span>
-</span><span id="38" class="l"><a href="#38">38: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> onExecute(Event <span class="php-var">$event</span>)
-</span><span id="39" class="l"><a href="#39">39: </a>    {
-</span><span id="40" class="l"><a href="#40">40: </a>        <span class="php-keyword1">if</span> (!<span class="php-var">$event</span>-&gt;getTarget() <span class="php-keyword1">instanceof</span> Model) {
-</span><span id="41" class="l"><a href="#41">41: </a>            <span class="php-keyword1">return</span>;
-</span><span id="42" class="l"><a href="#42">42: </a>        }
-</span><span id="43" class="l"><a href="#43">43: </a>        <span class="php-comment">/* @var $model Model */</span>
-</span><span id="44" class="l"><a href="#44">44: </a>        <span class="php-var">$model</span> = <span class="php-var">$event</span>-&gt;getTarget();
-</span><span id="45" class="l"><a href="#45">45: </a>        <span class="php-var">$entity</span> = <span class="php-var">$model</span>-&gt;getEntity();
-</span><span id="46" class="l"><a href="#46">46: </a>        <span class="php-var">$this</span>-&gt;getUpdate()
-</span><span id="47" class="l"><a href="#47">47: </a>            -&gt;setTable(<span class="php-var">$entity</span>-&gt;getTable())-&gt;setData(<span class="php-var">$model</span>-&gt;getData())
-</span><span id="48" class="l"><a href="#48">48: </a>            -&gt;setWhere(<span class="php-keyword1">new</span> ArrayWhere([<span class="php-var">$entity</span>-&gt;getIdField() =&gt; <span class="php-var">$model</span>-&gt;getId()]))
-</span><span id="49" class="l"><a href="#49">49: </a>            -&gt;execute(<span class="php-var">$this</span>-&gt;getAdapter());
-</span><span id="50" class="l"><a href="#50">50: </a>    }
-</span><span id="51" class="l"><a href="#51">51: </a>
-</span><span id="52" class="l"><a href="#52">52: </a>    <span class="php-comment">/**
-</span></span><span id="53" class="l"><a href="#53">53: </a><span class="php-comment">     * Returns a PHP Data Object
-</span></span><span id="54" class="l"><a href="#54">54: </a><span class="php-comment">     * @return PDO
-</span></span><span id="55" class="l"><a href="#55">55: </a><span class="php-comment">     * @since v1.0.0
-</span></span><span id="56" class="l"><a href="#56">56: </a><span class="php-comment">     */</span>
-</span><span id="57" class="l"><a href="#57">57: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> getAdapter()
-</span><span id="58" class="l"><a href="#58">58: </a>    {
-</span><span id="59" class="l"><a href="#59">59: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>-&gt;adapter;
-</span><span id="60" class="l"><a href="#60">60: </a>    }
-</span><span id="61" class="l"><a href="#61">61: </a>
-</span><span id="62" class="l"><a href="#62">62: </a>    <span class="php-comment">/**
-</span></span><span id="63" class="l"><a href="#63">63: </a><span class="php-comment">     * PDO connection to a db of some sort.
-</span></span><span id="64" class="l"><a href="#64">64: </a><span class="php-comment">     * @param PDO $adapter
-</span></span><span id="65" class="l"><a href="#65">65: </a><span class="php-comment">     * @return $this
-</span></span><span id="66" class="l"><a href="#66">66: </a><span class="php-comment">     * @since v1.0.0
-</span></span><span id="67" class="l"><a href="#67">67: </a><span class="php-comment">     */</span>
-</span><span id="68" class="l"><a href="#68">68: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> setAdapter(<span class="php-var">$adapter</span>)
-</span><span id="69" class="l"><a href="#69">69: </a>    {
-</span><span id="70" class="l"><a href="#70">70: </a>        <span class="php-var">$this</span>-&gt;adapter = <span class="php-var">$adapter</span>;
-</span><span id="71" class="l"><a href="#71">71: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>;
-</span><span id="72" class="l"><a href="#72">72: </a>    }
-</span><span id="73" class="l"><a href="#73">73: </a>
-</span><span id="74" class="l"><a href="#74">74: </a>    <span class="php-comment">/**
-</span></span><span id="75" class="l"><a href="#75">75: </a><span class="php-comment">     * object with logic for the Update. If Update is not provided one will be lazy loaded
-</span></span><span id="76" class="l"><a href="#76">76: </a><span class="php-comment">     * @return Update
-</span></span><span id="77" class="l"><a href="#77">77: </a><span class="php-comment">     * @since v1.0.0
-</span></span><span id="78" class="l"><a href="#78">78: </a><span class="php-comment">     */</span>
-</span><span id="79" class="l"><a href="#79">79: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> getUpdate()
-</span><span id="80" class="l"><a href="#80">80: </a>    {
-</span><span id="81" class="l"><a href="#81">81: </a>        <span class="php-keyword1">if</span> (!<span class="php-var">$this</span>-&gt;update <span class="php-keyword1">instanceof</span> Update) {
-</span><span id="82" class="l"><a href="#82">82: </a>            <span class="php-var">$this</span>-&gt;setUpdate(<span class="php-keyword1">new</span> Update(<span class="php-keyword1">null</span>, []));
-</span><span id="83" class="l"><a href="#83">83: </a>        }
-</span><span id="84" class="l"><a href="#84">84: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>-&gt;update;
-</span><span id="85" class="l"><a href="#85">85: </a>    }
-</span><span id="86" class="l"><a href="#86">86: </a>
-</span><span id="87" class="l"><a href="#87">87: </a>    <span class="php-comment">/**
-</span></span><span id="88" class="l"><a href="#88">88: </a><span class="php-comment">     * Object that contains the update logic
-</span></span><span id="89" class="l"><a href="#89">89: </a><span class="php-comment">     * @param Update $update
-</span></span><span id="90" class="l"><a href="#90">90: </a><span class="php-comment">     * @return $this
-</span></span><span id="91" class="l"><a href="#91">91: </a><span class="php-comment">     * @since v1.0.0
-</span></span><span id="92" class="l"><a href="#92">92: </a><span class="php-comment">     */</span>
-</span><span id="93" class="l"><a href="#93">93: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> setUpdate(Update <span class="php-var">$update</span> = <span class="php-keyword1">null</span>)
-</span><span id="94" class="l"><a href="#94">94: </a>    {
-</span><span id="95" class="l"><a href="#95">95: </a>        <span class="php-var">$this</span>-&gt;update = <span class="php-var">$update</span>;
-</span><span id="96" class="l"><a href="#96">96: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>;
-</span><span id="97" class="l"><a href="#97">97: </a>    }
-</span><span id="98" class="l"><a href="#98">98: </a>}
-</span><span id="99" class="l"><a href="#99">99: </a></span></code></pre>
+<pre><code><span id="1" class="l"><a href="#1">  1: </a><span class="xlang">&lt;?php</span>
+</span><span id="2" class="l"><a href="#2">  2: </a><span class="php-comment">/*
+</span></span><span id="3" class="l"><a href="#3">  3: </a><span class="php-comment"> * To change this license header, choose License Headers in Project Properties.
+</span></span><span id="4" class="l"><a href="#4">  4: </a><span class="php-comment"> * To change this template file, choose Tools | Templates
+</span></span><span id="5" class="l"><a href="#5">  5: </a><span class="php-comment"> * and open the template in the editor.
+</span></span><span id="6" class="l"><a href="#6">  6: </a><span class="php-comment"> */</span>
+</span><span id="7" class="l"><a href="#7">  7: </a><span class="php-keyword1">namespace</span> DSchoenbauer\Orm\Events\Persistence;
+</span><span id="8" class="l"><a href="#8">  8: </a>
+</span><span id="9" class="l"><a href="#9">  9: </a><span class="php-keyword1">use</span> DSchoenbauer\Orm\Events\AbstractEvent;
+</span><span id="10" class="l"><a href="#10"> 10: </a><span class="php-keyword1">use</span> DSchoenbauer\Orm\Model;
+</span><span id="11" class="l"><a href="#11"> 11: </a><span class="php-keyword1">use</span> DSchoenbauer\Sql\Command\Update;
+</span><span id="12" class="l"><a href="#12"> 12: </a><span class="php-keyword1">use</span> DSchoenbauer\Sql\Where\ArrayWhere;
+</span><span id="13" class="l"><a href="#13"> 13: </a><span class="php-keyword1">use</span> PDO;
+</span><span id="14" class="l"><a href="#14"> 14: </a><span class="php-keyword1">use</span> Zend\EventManager\Event;
+</span><span id="15" class="l"><a href="#15"> 15: </a>
+</span><span id="16" class="l"><a href="#16"> 16: </a><span class="php-comment">/**
+</span></span><span id="17" class="l"><a href="#17"> 17: </a><span class="php-comment"> * Event driven hook to update information from a PDO connection
+</span></span><span id="18" class="l"><a href="#18"> 18: </a><span class="php-comment"> *
+</span></span><span id="19" class="l"><a href="#19"> 19: </a><span class="php-comment"> * @author David Schoenbauer &lt;dschoenbauer@gmail.com&gt;
+</span></span><span id="20" class="l"><a href="#20"> 20: </a><span class="php-comment"> */</span>
+</span><span id="21" class="l"><a href="#21"> 21: </a><span class="php-keyword1">class</span> PdoUpdate <span class="php-keyword1">extends</span> AbstractEvent
+</span><span id="22" class="l"><a href="#22"> 22: </a>{
+</span><span id="23" class="l"><a href="#23"> 23: </a>
+</span><span id="24" class="l"><a href="#24"> 24: </a>    <span class="php-keyword1">private</span> <span class="php-var">$adapter</span>;
+</span><span id="25" class="l"><a href="#25"> 25: </a>    <span class="php-keyword1">private</span> <span class="php-var">$update</span>;
+</span><span id="26" class="l"><a href="#26"> 26: </a>
+</span><span id="27" class="l"><a href="#27"> 27: </a>    <span class="php-comment">/**
+</span></span><span id="28" class="l"><a href="#28"> 28: </a><span class="php-comment">     * @param array $events An array of event names to bind to
+</span></span><span id="29" class="l"><a href="#29"> 29: </a><span class="php-comment">     * @param PDO $adapter
+</span></span><span id="30" class="l"><a href="#30"> 30: </a><span class="php-comment">     * @param Update $update
+</span></span><span id="31" class="l"><a href="#31"> 31: </a><span class="php-comment">     */</span>
+</span><span id="32" class="l"><a href="#32"> 32: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> __construct(<span class="php-keyword1">array</span> <span class="php-var">$events</span>, PDO <span class="php-var">$adapter</span>, Update <span class="php-var">$update</span> = <span class="php-keyword1">null</span>)
+</span><span id="33" class="l"><a href="#33"> 33: </a>    {
+</span><span id="34" class="l"><a href="#34"> 34: </a>        parent::__construct(<span class="php-var">$events</span>);
+</span><span id="35" class="l"><a href="#35"> 35: </a>        <span class="php-var">$this</span>-&gt;setAdapter(<span class="php-var">$adapter</span>)-&gt;setUpdate(<span class="php-var">$update</span>);
+</span><span id="36" class="l"><a href="#36"> 36: </a>    }
+</span><span id="37" class="l"><a href="#37"> 37: </a>
+</span><span id="38" class="l"><a href="#38"> 38: </a>    <span class="php-comment">/**
+</span></span><span id="39" class="l"><a href="#39"> 39: </a><span class="php-comment">     * event action
+</span></span><span id="40" class="l"><a href="#40"> 40: </a><span class="php-comment">     * @param Event $event object passed when event is fired
+</span></span><span id="41" class="l"><a href="#41"> 41: </a><span class="php-comment">     * @return void
+</span></span><span id="42" class="l"><a href="#42"> 42: </a><span class="php-comment">     * @since v1.0.0
+</span></span><span id="43" class="l"><a href="#43"> 43: </a><span class="php-comment">     */</span>
+</span><span id="44" class="l"><a href="#44"> 44: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> onExecute(Event <span class="php-var">$event</span>)
+</span><span id="45" class="l"><a href="#45"> 45: </a>    {
+</span><span id="46" class="l"><a href="#46"> 46: </a>        <span class="php-keyword1">if</span> (!<span class="php-var">$event</span>-&gt;getTarget() <span class="php-keyword1">instanceof</span> Model) {
+</span><span id="47" class="l"><a href="#47"> 47: </a>            <span class="php-keyword1">return</span>;
+</span><span id="48" class="l"><a href="#48"> 48: </a>        }
+</span><span id="49" class="l"><a href="#49"> 49: </a>        <span class="php-comment">/* @var $model Model */</span>
+</span><span id="50" class="l"><a href="#50"> 50: </a>        <span class="php-var">$model</span> = <span class="php-var">$event</span>-&gt;getTarget();
+</span><span id="51" class="l"><a href="#51"> 51: </a>        <span class="php-var">$entity</span> = <span class="php-var">$model</span>-&gt;getEntity();
+</span><span id="52" class="l"><a href="#52"> 52: </a>        <span class="php-var">$this</span>-&gt;getUpdate()
+</span><span id="53" class="l"><a href="#53"> 53: </a>            -&gt;setTable(<span class="php-var">$entity</span>-&gt;getTable())-&gt;setData(<span class="php-var">$model</span>-&gt;getData())
+</span><span id="54" class="l"><a href="#54"> 54: </a>            -&gt;setWhere(<span class="php-keyword1">new</span> ArrayWhere([<span class="php-var">$entity</span>-&gt;getIdField() =&gt; <span class="php-var">$model</span>-&gt;getId()]))
+</span><span id="55" class="l"><a href="#55"> 55: </a>            -&gt;execute(<span class="php-var">$this</span>-&gt;getAdapter());
+</span><span id="56" class="l"><a href="#56"> 56: </a>    }
+</span><span id="57" class="l"><a href="#57"> 57: </a>
+</span><span id="58" class="l"><a href="#58"> 58: </a>    <span class="php-comment">/**
+</span></span><span id="59" class="l"><a href="#59"> 59: </a><span class="php-comment">     * Returns a PHP Data Object
+</span></span><span id="60" class="l"><a href="#60"> 60: </a><span class="php-comment">     * @return PDO
+</span></span><span id="61" class="l"><a href="#61"> 61: </a><span class="php-comment">     * @since v1.0.0
+</span></span><span id="62" class="l"><a href="#62"> 62: </a><span class="php-comment">     */</span>
+</span><span id="63" class="l"><a href="#63"> 63: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> getAdapter()
+</span><span id="64" class="l"><a href="#64"> 64: </a>    {
+</span><span id="65" class="l"><a href="#65"> 65: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>-&gt;adapter;
+</span><span id="66" class="l"><a href="#66"> 66: </a>    }
+</span><span id="67" class="l"><a href="#67"> 67: </a>
+</span><span id="68" class="l"><a href="#68"> 68: </a>    <span class="php-comment">/**
+</span></span><span id="69" class="l"><a href="#69"> 69: </a><span class="php-comment">     * PDO connection to a db of some sort.
+</span></span><span id="70" class="l"><a href="#70"> 70: </a><span class="php-comment">     * @param PDO $adapter
+</span></span><span id="71" class="l"><a href="#71"> 71: </a><span class="php-comment">     * @return $this
+</span></span><span id="72" class="l"><a href="#72"> 72: </a><span class="php-comment">     * @since v1.0.0
+</span></span><span id="73" class="l"><a href="#73"> 73: </a><span class="php-comment">     */</span>
+</span><span id="74" class="l"><a href="#74"> 74: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> setAdapter(<span class="php-var">$adapter</span>)
+</span><span id="75" class="l"><a href="#75"> 75: </a>    {
+</span><span id="76" class="l"><a href="#76"> 76: </a>        <span class="php-var">$this</span>-&gt;adapter = <span class="php-var">$adapter</span>;
+</span><span id="77" class="l"><a href="#77"> 77: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>;
+</span><span id="78" class="l"><a href="#78"> 78: </a>    }
+</span><span id="79" class="l"><a href="#79"> 79: </a>
+</span><span id="80" class="l"><a href="#80"> 80: </a>    <span class="php-comment">/**
+</span></span><span id="81" class="l"><a href="#81"> 81: </a><span class="php-comment">     * object with logic for the Update. If Update is not provided one will be lazy loaded
+</span></span><span id="82" class="l"><a href="#82"> 82: </a><span class="php-comment">     * @return Update
+</span></span><span id="83" class="l"><a href="#83"> 83: </a><span class="php-comment">     * @since v1.0.0
+</span></span><span id="84" class="l"><a href="#84"> 84: </a><span class="php-comment">     */</span>
+</span><span id="85" class="l"><a href="#85"> 85: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> getUpdate()
+</span><span id="86" class="l"><a href="#86"> 86: </a>    {
+</span><span id="87" class="l"><a href="#87"> 87: </a>        <span class="php-keyword1">if</span> (!<span class="php-var">$this</span>-&gt;update <span class="php-keyword1">instanceof</span> Update) {
+</span><span id="88" class="l"><a href="#88"> 88: </a>            <span class="php-var">$this</span>-&gt;setUpdate(<span class="php-keyword1">new</span> Update(<span class="php-keyword1">null</span>, []));
+</span><span id="89" class="l"><a href="#89"> 89: </a>        }
+</span><span id="90" class="l"><a href="#90"> 90: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>-&gt;update;
+</span><span id="91" class="l"><a href="#91"> 91: </a>    }
+</span><span id="92" class="l"><a href="#92"> 92: </a>
+</span><span id="93" class="l"><a href="#93"> 93: </a>    <span class="php-comment">/**
+</span></span><span id="94" class="l"><a href="#94"> 94: </a><span class="php-comment">     * Object that contains the update logic
+</span></span><span id="95" class="l"><a href="#95"> 95: </a><span class="php-comment">     * @param Update $update
+</span></span><span id="96" class="l"><a href="#96"> 96: </a><span class="php-comment">     * @return $this
+</span></span><span id="97" class="l"><a href="#97"> 97: </a><span class="php-comment">     * @since v1.0.0
+</span></span><span id="98" class="l"><a href="#98"> 98: </a><span class="php-comment">     */</span>
+</span><span id="99" class="l"><a href="#99"> 99: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> setUpdate(Update <span class="php-var">$update</span> = <span class="php-keyword1">null</span>)
+</span><span id="100" class="l"><a href="#100">100: </a>    {
+</span><span id="101" class="l"><a href="#101">101: </a>        <span class="php-var">$this</span>-&gt;update = <span class="php-var">$update</span>;
+</span><span id="102" class="l"><a href="#102">102: </a>        <span class="php-keyword1">return</span> <span class="php-var">$this</span>;
+</span><span id="103" class="l"><a href="#103">103: </a>    }
+</span><span id="104" class="l"><a href="#104">104: </a>}
+</span><span id="105" class="l"><a href="#105">105: </a></span></code></pre>
 
 	<div id="footer">
 		 API documentation generated by <a href="http://apigen.org">ApiGen</a>

--- a/docs/source-class-DSchoenbauer.Orm.Events.Validate.Schema.DefaultValue.html
+++ b/docs/source-class-DSchoenbauer.Orm.Events.Validate.Schema.DefaultValue.html
@@ -190,57 +190,49 @@
 </span><span id="25" class="l"><a href="#25">25: </a><span class="php-keyword1">namespace</span> DSchoenbauer\Orm\Events\Validate\Schema;
 </span><span id="26" class="l"><a href="#26">26: </a>
 </span><span id="27" class="l"><a href="#27">27: </a><span class="php-keyword1">use</span> DSchoenbauer\Orm\Entity\HasDefaultValuesInterface;
-</span><span id="28" class="l"><a href="#28">28: </a><span class="php-keyword1">use</span> DSchoenbauer\Orm\Enum\ModelEvents;
-</span><span id="29" class="l"><a href="#29">29: </a><span class="php-keyword1">use</span> DSchoenbauer\Orm\Events\Validate\AbstractValidate;
-</span><span id="30" class="l"><a href="#30">30: </a>
-</span><span id="31" class="l"><a href="#31">31: </a><span class="php-comment">/**
-</span></span><span id="32" class="l"><a href="#32">32: </a><span class="php-comment"> * Adds a default value to a data set at create time
-</span></span><span id="33" class="l"><a href="#33">33: </a><span class="php-comment"> *
-</span></span><span id="34" class="l"><a href="#34">34: </a><span class="php-comment"> * @author David Schoenbauer
-</span></span><span id="35" class="l"><a href="#35">35: </a><span class="php-comment"> */</span>
-</span><span id="36" class="l"><a href="#36">36: </a><span class="php-keyword1">class</span> DefaultValue <span class="php-keyword1">extends</span> AbstractValidate
-</span><span id="37" class="l"><a href="#37">37: </a>{
-</span><span id="38" class="l"><a href="#38">38: </a>
-</span><span id="39" class="l"><a href="#39">39: </a>    <span class="php-comment">/**
-</span></span><span id="40" class="l"><a href="#40">40: </a><span class="php-comment">     * provides an associative array that has a key of the field and a value
-</span></span><span id="41" class="l"><a href="#41">41: </a><span class="php-comment">     * @param HasDefaultValuesInterface $entity
-</span></span><span id="42" class="l"><a href="#42">42: </a><span class="php-comment">     * @return array
-</span></span><span id="43" class="l"><a href="#43">43: </a><span class="php-comment">     * @since v1.0.0
-</span></span><span id="44" class="l"><a href="#44">44: </a><span class="php-comment">     */</span>
-</span><span id="45" class="l"><a href="#45">45: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> getFields(<span class="php-var">$entity</span>)
-</span><span id="46" class="l"><a href="#46">46: </a>    {
-</span><span id="47" class="l"><a href="#47">47: </a>        <span class="php-keyword1">return</span> <span class="php-var">$entity</span>-&gt;getDefaultValues();
-</span><span id="48" class="l"><a href="#48">48: </a>    }
-</span><span id="49" class="l"><a href="#49">49: </a>
-</span><span id="50" class="l"><a href="#50">50: </a>    <span class="php-comment">/**
-</span></span><span id="51" class="l"><a href="#51">51: </a><span class="php-comment">     * @inheritDoc
-</span></span><span id="52" class="l"><a href="#52">52: </a><span class="php-comment">     * @return string
-</span></span><span id="53" class="l"><a href="#53">53: </a><span class="php-comment">     */</span>
-</span><span id="54" class="l"><a href="#54">54: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> getTypeInterface()
-</span><span id="55" class="l"><a href="#55">55: </a>    {
-</span><span id="56" class="l"><a href="#56">56: </a>        <span class="php-keyword1">return</span> HasDefaultValuesInterface::<span class="php-keyword1">class</span>;
-</span><span id="57" class="l"><a href="#57">57: </a>    }
-</span><span id="58" class="l"><a href="#58">58: </a>    
-</span><span id="59" class="l"><a href="#59">59: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> preExecuteCheck()
-</span><span id="60" class="l"><a href="#60">60: </a>    {
-</span><span id="61" class="l"><a href="#61">61: </a>        <span class="php-keyword1">return</span> <span class="php-keyword2">is_array</span>(<span class="php-var">$params</span> = <span class="php-var">$this</span>-&gt;getParams()) &amp;&amp;
-</span><span id="62" class="l"><a href="#62">62: </a>            <span class="php-keyword2">array_key_exists</span>(<span class="php-quote">'events'</span>, <span class="php-var">$params</span>) &amp;&amp;
-</span><span id="63" class="l"><a href="#63">63: </a>            <span class="php-keyword2">is_array</span>(<span class="php-var">$params</span>[<span class="php-quote">'events'</span>]) &amp;&amp;
-</span><span id="64" class="l"><a href="#64">64: </a>            <span class="php-keyword2">in_array</span>(ModelEvents::CREATE, <span class="php-var">$params</span>[<span class="php-quote">'events'</span>]);
-</span><span id="65" class="l"><a href="#65">65: </a>    }
-</span><span id="66" class="l"><a href="#66">66: </a>
-</span><span id="67" class="l"><a href="#67">67: </a>    <span class="php-comment">/**
-</span></span><span id="68" class="l"><a href="#68">68: </a><span class="php-comment">     *
-</span></span><span id="69" class="l"><a href="#69">69: </a><span class="php-comment">     * @param array $data
-</span></span><span id="70" class="l"><a href="#70">70: </a><span class="php-comment">     * @param array $fields
-</span></span><span id="71" class="l"><a href="#71">71: </a><span class="php-comment">     */</span>
-</span><span id="72" class="l"><a href="#72">72: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> validate(<span class="php-keyword1">array</span> <span class="php-var">$data</span>, <span class="php-keyword1">array</span> <span class="php-var">$fields</span>)
-</span><span id="73" class="l"><a href="#73">73: </a>    {
-</span><span id="74" class="l"><a href="#74">74: </a>        <span class="php-var">$this</span>-&gt;getModel()-&gt;setData(<span class="php-keyword2">array_merge</span>(<span class="php-var">$fields</span>, <span class="php-var">$data</span>));
-</span><span id="75" class="l"><a href="#75">75: </a>        <span class="php-keyword1">return</span> <span class="php-keyword1">true</span>;
-</span><span id="76" class="l"><a href="#76">76: </a>    }
-</span><span id="77" class="l"><a href="#77">77: </a>}
-</span><span id="78" class="l"><a href="#78">78: </a></span></code></pre>
+</span><span id="28" class="l"><a href="#28">28: </a><span class="php-keyword1">use</span> DSchoenbauer\Orm\Events\Validate\AbstractValidate;
+</span><span id="29" class="l"><a href="#29">29: </a>
+</span><span id="30" class="l"><a href="#30">30: </a><span class="php-comment">/**
+</span></span><span id="31" class="l"><a href="#31">31: </a><span class="php-comment"> * Adds a default value to a data set at create time
+</span></span><span id="32" class="l"><a href="#32">32: </a><span class="php-comment"> *
+</span></span><span id="33" class="l"><a href="#33">33: </a><span class="php-comment"> * @author David Schoenbauer
+</span></span><span id="34" class="l"><a href="#34">34: </a><span class="php-comment"> */</span>
+</span><span id="35" class="l"><a href="#35">35: </a><span class="php-keyword1">class</span> DefaultValue <span class="php-keyword1">extends</span> AbstractValidate
+</span><span id="36" class="l"><a href="#36">36: </a>{
+</span><span id="37" class="l"><a href="#37">37: </a>
+</span><span id="38" class="l"><a href="#38">38: </a>    <span class="php-comment">/**
+</span></span><span id="39" class="l"><a href="#39">39: </a><span class="php-comment">     * provides an associative array that has a key of the field and a value
+</span></span><span id="40" class="l"><a href="#40">40: </a><span class="php-comment">     * @param HasDefaultValuesInterface $entity
+</span></span><span id="41" class="l"><a href="#41">41: </a><span class="php-comment">     * @return array
+</span></span><span id="42" class="l"><a href="#42">42: </a><span class="php-comment">     * @since v1.0.0
+</span></span><span id="43" class="l"><a href="#43">43: </a><span class="php-comment">     */</span>
+</span><span id="44" class="l"><a href="#44">44: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> getFields(<span class="php-var">$entity</span>)
+</span><span id="45" class="l"><a href="#45">45: </a>    {
+</span><span id="46" class="l"><a href="#46">46: </a>        <span class="php-keyword1">return</span> <span class="php-var">$entity</span>-&gt;getDefaultValues();
+</span><span id="47" class="l"><a href="#47">47: </a>    }
+</span><span id="48" class="l"><a href="#48">48: </a>
+</span><span id="49" class="l"><a href="#49">49: </a>    <span class="php-comment">/**
+</span></span><span id="50" class="l"><a href="#50">50: </a><span class="php-comment">     * @inheritDoc
+</span></span><span id="51" class="l"><a href="#51">51: </a><span class="php-comment">     * @return string
+</span></span><span id="52" class="l"><a href="#52">52: </a><span class="php-comment">     */</span>
+</span><span id="53" class="l"><a href="#53">53: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> getTypeInterface()
+</span><span id="54" class="l"><a href="#54">54: </a>    {
+</span><span id="55" class="l"><a href="#55">55: </a>        <span class="php-keyword1">return</span> HasDefaultValuesInterface::<span class="php-keyword1">class</span>;
+</span><span id="56" class="l"><a href="#56">56: </a>    }
+</span><span id="57" class="l"><a href="#57">57: </a>    
+</span><span id="58" class="l"><a href="#58">58: </a>
+</span><span id="59" class="l"><a href="#59">59: </a>    <span class="php-comment">/**
+</span></span><span id="60" class="l"><a href="#60">60: </a><span class="php-comment">     *
+</span></span><span id="61" class="l"><a href="#61">61: </a><span class="php-comment">     * @param array $data
+</span></span><span id="62" class="l"><a href="#62">62: </a><span class="php-comment">     * @param array $fields
+</span></span><span id="63" class="l"><a href="#63">63: </a><span class="php-comment">     */</span>
+</span><span id="64" class="l"><a href="#64">64: </a>    <span class="php-keyword1">public</span> <span class="php-keyword1">function</span> validate(<span class="php-keyword1">array</span> <span class="php-var">$data</span>, <span class="php-keyword1">array</span> <span class="php-var">$fields</span>)
+</span><span id="65" class="l"><a href="#65">65: </a>    {
+</span><span id="66" class="l"><a href="#66">66: </a>        <span class="php-var">$this</span>-&gt;getModel()-&gt;setData(<span class="php-keyword2">array_merge</span>(<span class="php-var">$fields</span>, <span class="php-var">$data</span>));
+</span><span id="67" class="l"><a href="#67">67: </a>        <span class="php-keyword1">return</span> <span class="php-keyword1">true</span>;
+</span><span id="68" class="l"><a href="#68">68: </a>    }
+</span><span id="69" class="l"><a href="#69">69: </a>}
+</span><span id="70" class="l"><a href="#70">70: </a></span></code></pre>
 
 	<div id="footer">
 		 API documentation generated by <a href="http://apigen.org">ApiGen</a>

--- a/src/Orm/CrudModel.php
+++ b/src/Orm/CrudModel.php
@@ -43,8 +43,8 @@ class CrudModel extends Model
     public function create($data)
     {
         $this->setData($data);
-        $events = [ModelEvents::CREATE, ModelEvents::FETCH];
-        $this->processEvents($events);
+        $this->getEventManager()->trigger(ModelEvents::CREATE, $this);
+        $this->getEventManager()->trigger(ModelEvents::FETCH, $this);
         return $this->getData();
     }
 
@@ -57,8 +57,7 @@ class CrudModel extends Model
     public function fetch($id)
     {
         $this->setId($id);
-        $events = [ModelEvents::FETCH];
-        $this->processEvents($events);
+        $this->getEventManager()->trigger(ModelEvents::FETCH, $this);
         return $this->getData();
     }
 
@@ -69,8 +68,7 @@ class CrudModel extends Model
      */
     public function fetchAll()
     {
-        $events = [ModelEvents::FETCH_ALL];
-        $this->processEvents($events);
+        $this->getEventManager()->trigger(ModelEvents::FETCH_ALL, $this);
         return $this->getData();
     }
 
@@ -84,8 +82,8 @@ class CrudModel extends Model
     public function update($id, $data)
     {
         $this->setId($id)->setData($data);
-        $events = [ModelEvents::UPDATE, ModelEvents::FETCH];
-        $this->processEvents($events);
+        $this->getEventManager()->trigger(ModelEvents::UPDATE, $this);
+        $this->getEventManager()->trigger(ModelEvents::FETCH, $this);
         return $this->getData();
     }
 
@@ -98,27 +96,7 @@ class CrudModel extends Model
     public function delete($id)
     {
         $this->setId($id);
-        $events = [ModelEvents::DELETE];
-        $this->processEvents($events);
+        $this->getEventManager()->trigger(ModelEvents::DELETE, $this);
         return true;
-    }
-
-    /**
-     * Attaches given events into the event manager
-     * @param array $events
-     * @return CrudModel
-     * @since v1.0.0
-     */
-    protected function processEvents(array $events)
-    {
-        $this->getEventManager()->trigger(
-            ModelEvents::VALIDATE,
-            $this,
-            compact('events')
-        );
-        foreach ($events as $event) {
-            $this->getEventManager()->trigger($event, $this);
-        }
-        return $this;
     }
 }

--- a/src/Orm/Enum/ModelEvents.php
+++ b/src/Orm/Enum/ModelEvents.php
@@ -31,11 +31,6 @@ namespace DSchoenbauer\Orm\Enum;
  */
 class ModelEvents
 {
-
-    /**
-     * Called to validate data
-     */
-    const VALIDATE = 'validate';
     
     /**
      * Called to create a new record

--- a/src/Orm/Events/AbstractEvent.php
+++ b/src/Orm/Events/AbstractEvent.php
@@ -37,6 +37,12 @@ abstract class AbstractEvent implements VisitorInterface
 {
 
     private $events = [];
+    
+    public function __construct(array $events = [])
+    {
+        $this->setEvents($events);
+    }
+    
 
     /**
      * provides an opportunity to extend Model's functionality

--- a/src/Orm/Events/Persistence/PdoCreate.php
+++ b/src/Orm/Events/Persistence/PdoCreate.php
@@ -26,13 +26,15 @@ class PdoCreate extends AbstractEvent
 
     /**
      *
+     * @param array $events An array of event names to bind to
      * @param PDO $adapter PDO connection to a db of some sort.
      * @param Create $create default null, if no create object offered one will
      * be lazy loaded for you
      * @since v1.0.0
      */
-    public function __construct(PDO $adapter, Create $create = null)
+    public function __construct(array $events, PDO $adapter, Create $create = null)
     {
+        parent::__construct($events);
         $this->setAdapter($adapter)->setCreate($create);
     }
 

--- a/src/Orm/Events/Persistence/PdoDelete.php
+++ b/src/Orm/Events/Persistence/PdoDelete.php
@@ -24,8 +24,14 @@ class PdoDelete extends AbstractEvent
     private $adapter;
     private $delete;
 
-    public function __construct(PDO $adapter, Delete $delete = null)
+    /**
+     * @param array $events An array of event names to bind to
+     * @param PDO $adapter
+     * @param Delete $delete
+     */
+    public function __construct(array $events, PDO $adapter, Delete $delete = null)
     {
+        parent::__construct($events);
         $this->setAdapter($adapter)->setDelete($delete);
     }
 

--- a/src/Orm/Events/Persistence/PdoSelect.php
+++ b/src/Orm/Events/Persistence/PdoSelect.php
@@ -43,10 +43,15 @@ class PdoSelect extends AbstractEvent
     private $adapter;
     private $select;
 
-    public function __construct(\PDO $adapter, Select $select = null)
+    /**
+     * @param array $events An array of event names to bind to
+     * @param PDO $adapter
+     * @param Select $select
+     */
+    public function __construct(array $events, \PDO $adapter, Select $select = null)
     {
-        $this->setEvents([ModelEvents::FETCH])
-            ->setAdapter($adapter)
+        parent::__construct($events);
+        $this->setAdapter($adapter)
             ->setSelect($select);
     }
 

--- a/src/Orm/Events/Persistence/PdoUpdate.php
+++ b/src/Orm/Events/Persistence/PdoUpdate.php
@@ -24,8 +24,14 @@ class PdoUpdate extends AbstractEvent
     private $adapter;
     private $update;
 
-    public function __construct(PDO $adapter, Update $update = null)
+    /**
+     * @param array $events An array of event names to bind to
+     * @param PDO $adapter
+     * @param Update $update
+     */
+    public function __construct(array $events, PDO $adapter, Update $update = null)
     {
+        parent::__construct($events);
         $this->setAdapter($adapter)->setUpdate($update);
     }
 

--- a/src/Orm/Events/Validate/Schema/DefaultValue.php
+++ b/src/Orm/Events/Validate/Schema/DefaultValue.php
@@ -25,7 +25,6 @@
 namespace DSchoenbauer\Orm\Events\Validate\Schema;
 
 use DSchoenbauer\Orm\Entity\HasDefaultValuesInterface;
-use DSchoenbauer\Orm\Enum\ModelEvents;
 use DSchoenbauer\Orm\Events\Validate\AbstractValidate;
 
 /**
@@ -56,13 +55,6 @@ class DefaultValue extends AbstractValidate
         return HasDefaultValuesInterface::class;
     }
     
-    public function preExecuteCheck()
-    {
-        return is_array($params = $this->getParams()) &&
-            array_key_exists('events', $params) &&
-            is_array($params['events']) &&
-            in_array(ModelEvents::CREATE, $params['events']);
-    }
 
     /**
      *

--- a/tests/src/Orm/CrudModelTest.php
+++ b/tests/src/Orm/CrudModelTest.php
@@ -48,10 +48,9 @@ class CrudModelTest extends PHPUnit_Framework_TestCase
 
     public function testCreate()
     {
-        $this->mockEventManager->expects($this->exactly(3))
+        $this->mockEventManager->expects($this->exactly(2))
             ->method('trigger')
             ->withConsecutive(
-                [Enum\ModelEvents::VALIDATE, $this->object, ['events' => [Enum\ModelEvents::CREATE, Enum\ModelEvents::FETCH]]],
                 [Enum\ModelEvents::CREATE, $this->object],
                 [Enum\ModelEvents::FETCH, $this->object]);
 
@@ -63,10 +62,9 @@ class CrudModelTest extends PHPUnit_Framework_TestCase
 
     public function testFetch()
     {
-        $this->mockEventManager->expects($this->exactly(2))
+        $this->mockEventManager->expects($this->exactly(1))
             ->method('trigger')
             ->withConsecutive(
-                [Enum\ModelEvents::VALIDATE, $this->object, ['events' => [Enum\ModelEvents::FETCH]]],
                 [Enum\ModelEvents::FETCH, $this->object]);
 
         $this->object->setEventManager($this->mockEventManager);
@@ -78,10 +76,9 @@ class CrudModelTest extends PHPUnit_Framework_TestCase
 
     public function testFetchAll()
     {
-        $this->mockEventManager->expects($this->exactly(2))
+        $this->mockEventManager->expects($this->exactly(1))
             ->method('trigger')
             ->withConsecutive(
-                [Enum\ModelEvents::VALIDATE, $this->object, ['events' => [Enum\ModelEvents::FETCH_ALL]]],
                 [Enum\ModelEvents::FETCH_ALL, $this->object]);
 
         $this->object->setEventManager($this->mockEventManager);
@@ -91,10 +88,9 @@ class CrudModelTest extends PHPUnit_Framework_TestCase
 
     public function testUpdate()
     {
-        $this->mockEventManager->expects($this->exactly(3))
+        $this->mockEventManager->expects($this->exactly(2))
             ->method('trigger')
             ->withConsecutive(
-                [Enum\ModelEvents::VALIDATE, $this->object, ['events' => [Enum\ModelEvents::UPDATE, Enum\ModelEvents::FETCH]]],
                 [Enum\ModelEvents::UPDATE, $this->object],
                 [Enum\ModelEvents::FETCH, $this->object]
         );
@@ -109,10 +105,9 @@ class CrudModelTest extends PHPUnit_Framework_TestCase
 
     public function testDelete()
     {
-        $this->mockEventManager->expects($this->exactly(2))
+        $this->mockEventManager->expects($this->exactly(1))
             ->method('trigger')
             ->withConsecutive(
-                [Enum\ModelEvents::VALIDATE, $this->object, ['events' => [Enum\ModelEvents::DELETE]]],
                 [Enum\ModelEvents::DELETE, $this->object]);
 
         $this->object->setEventManager($this->mockEventManager);

--- a/tests/src/Orm/Events/Persistence/PdoCreateTest.php
+++ b/tests/src/Orm/Events/Persistence/PdoCreateTest.php
@@ -27,7 +27,7 @@ class PdoCreateTest extends PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->mockAdapter = $this->getMockBuilder(PDO::class)->disableOriginalConstructor()->getMock();
-        $this->object = new PdoCreate($this->mockAdapter);
+        $this->object = new PdoCreate([], $this->mockAdapter);
     }
 
     public function testAdapterFromContructor()
@@ -38,22 +38,20 @@ class PdoCreateTest extends PHPUnit_Framework_TestCase
     public function testAdapter()
     {
         $mockAdapter = $this->getMockBuilder(PDO::class)->disableOriginalConstructor()->getMock();
-        $this->assertSame($mockAdapter,
-            $this->object->setAdapter($mockAdapter)->getAdapter());
+        $this->assertSame($mockAdapter, $this->object->setAdapter($mockAdapter)->getAdapter());
     }
 
     public function testCreateConstructor()
     {
         $mockCreate = $this->getMockBuilder(Create::class)->disableOriginalConstructor()->getMock();
-        $subject = new PdoCreate($this->mockAdapter, $mockCreate);
+        $subject = new PdoCreate([], $this->mockAdapter, $mockCreate);
         $this->assertSame($mockCreate, $subject->getCreate());
     }
 
     public function testCreate()
     {
         $mockCreate = $this->getMockBuilder(Create::class)->disableOriginalConstructor()->getMock();
-        $this->assertSame($mockCreate,
-            $this->object->setCreate($mockCreate)->getCreate());
+        $this->assertSame($mockCreate, $this->object->setCreate($mockCreate)->getCreate());
     }
 
     public function testCreateLazyLoad()
@@ -74,7 +72,7 @@ class PdoCreateTest extends PHPUnit_Framework_TestCase
     {
         $table = "someTable";
         $idField = "id";
-        $data = ['test'=>1,'some_id'=>2];
+        $data = ['test' => 1, 'some_id' => 2];
 
         $entity = $this->getMockBuilder(EntityInterface::class)->getMock();
         $entity->expects($this->once())->method('getTable')->willReturn($table);

--- a/tests/src/Orm/Events/Persistence/PdoDeleteTest.php
+++ b/tests/src/Orm/Events/Persistence/PdoDeleteTest.php
@@ -27,7 +27,7 @@ class PdoDeleteTest extends PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->mockAdapter = $this->getMockBuilder(PDO::class)->disableOriginalConstructor()->getMock();
-        $this->object = new PdoDelete($this->mockAdapter);
+        $this->object = new PdoDelete([], $this->mockAdapter);
     }
 
     public function testAdapterFromContructor()
@@ -38,22 +38,20 @@ class PdoDeleteTest extends PHPUnit_Framework_TestCase
     public function testAdapter()
     {
         $mockAdapter = $this->getMockBuilder(PDO::class)->disableOriginalConstructor()->getMock();
-        $this->assertSame($mockAdapter,
-            $this->object->setAdapter($mockAdapter)->getAdapter());
+        $this->assertSame($mockAdapter, $this->object->setAdapter($mockAdapter)->getAdapter());
     }
 
     public function testDeleteConstructor()
     {
         $mockDelete = $this->getMockBuilder(Delete::class)->disableOriginalConstructor()->getMock();
-        $subject = new PdoDelete($this->mockAdapter, $mockDelete);
+        $subject = new PdoDelete([], $this->mockAdapter, $mockDelete);
         $this->assertSame($mockDelete, $subject->getDelete());
     }
 
     public function testDelete()
     {
         $mockDelete = $this->getMockBuilder(Delete::class)->disableOriginalConstructor()->getMock();
-        $this->assertSame($mockDelete,
-            $this->object->setDelete($mockDelete)->getDelete());
+        $this->assertSame($mockDelete, $this->object->setDelete($mockDelete)->getDelete());
     }
 
     public function testDeleteLazyLoad()

--- a/tests/src/Orm/Events/Persistence/PdoSelectTest.php
+++ b/tests/src/Orm/Events/Persistence/PdoSelectTest.php
@@ -46,7 +46,7 @@ class PdoSelectTest extends PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->mockAdapter = $this->getMockBuilder(PDO::class)->disableOriginalConstructor()->getMock();
-        $this->object = new PdoSelect($this->mockAdapter);
+        $this->object = new PdoSelect([], $this->mockAdapter);
     }
 
     public function testAdapterFromContructor()
@@ -63,7 +63,7 @@ class PdoSelectTest extends PHPUnit_Framework_TestCase
     public function testSelectConstructor()
     {
         $mockSelect = $this->getMockBuilder(Select::class)->disableOriginalConstructor()->getMock();
-        $subject = new PdoSelect($this->mockAdapter, $mockSelect);
+        $subject = new PdoSelect([], $this->mockAdapter, $mockSelect);
         $this->assertSame($mockSelect, $subject->getSelect());
     }
 
@@ -77,28 +77,30 @@ class PdoSelectTest extends PHPUnit_Framework_TestCase
     {
         $this->assertInstanceOf(Select::class, $this->object->getSelect());
     }
-    
-    public function testOnExecuteTargetNotModel(){
+
+    public function testOnExecuteTargetNotModel()
+    {
         $event = $this->getMockBuilder(Event::class)->getMock();
         $event->expects($this->once())
             ->method('getTarget')
             ->willReturn(null);
         $this->assertNull($this->object->onExecute($event));
     }
-    
-    public function testOnExecute(){
+
+    public function testOnExecute()
+    {
         $table = "someTable";
-        $fields = ["some","fields"];
+        $fields = ["some", "fields"];
         $idField = "id";
-        
+
         $model = $this->getMockBuilder(Model::class)->disableOriginalConstructor()->getMock();
         $model->expects($this->once())->method('getId')->willReturn(1);
-        
+
         $entity = $this->getMockBuilder(EntityInterface::class)->getMock();
         $entity->expects($this->once())->method('getTable')->willReturn($table);
         $entity->expects($this->once())->method('getAllFields')->willReturn($fields);
         $entity->expects($this->once())->method('getIdField')->willReturn($idField);
-        
+
         $select = $this->getMockBuilder(Select::class)->disableOriginalConstructor()->getMock();
         $select->expects($this->once())->method('setTable')->with($table)->willReturnSelf();
         $select->expects($this->once())->method('setFields')->with($fields)->willReturnSelf();
@@ -106,12 +108,12 @@ class PdoSelectTest extends PHPUnit_Framework_TestCase
         $select->expects($this->once())->method('setFetchFlat')->willReturnSelf();
         $select->expects($this->once())->method('execute')->with($this->mockAdapter);
 
-        
+
         $model->expects($this->once())->method('getEntity')->willReturn($entity);
 
         $event = $this->getMockBuilder(Event::class)->getMock();
         $event->expects($this->exactly(2))->method('getTarget')->willReturn($model);
-        
+
         $this->assertNull($this->object->setSelect($select)->onExecute($event));
     }
 }

--- a/tests/src/Orm/Events/Persistence/PdoUpdateTest.php
+++ b/tests/src/Orm/Events/Persistence/PdoUpdateTest.php
@@ -27,7 +27,7 @@ class PdoUpdateTest extends PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->mockAdapter = $this->getMockBuilder(PDO::class)->disableOriginalConstructor()->getMock();
-        $this->object = new PdoUpdate($this->mockAdapter);
+        $this->object = new PdoUpdate([], $this->mockAdapter);
     }
 
     public function testAdapterFromContructor()
@@ -38,22 +38,20 @@ class PdoUpdateTest extends PHPUnit_Framework_TestCase
     public function testAdapter()
     {
         $mockAdapter = $this->getMockBuilder(PDO::class)->disableOriginalConstructor()->getMock();
-        $this->assertSame($mockAdapter,
-            $this->object->setAdapter($mockAdapter)->getAdapter());
+        $this->assertSame($mockAdapter, $this->object->setAdapter($mockAdapter)->getAdapter());
     }
 
     public function testUpdateConstructor()
     {
         $mockUpdate = $this->getMockBuilder(Update::class)->disableOriginalConstructor()->getMock();
-        $subject = new PdoUpdate($this->mockAdapter, $mockUpdate);
+        $subject = new PdoUpdate([], $this->mockAdapter, $mockUpdate);
         $this->assertSame($mockUpdate, $subject->getUpdate());
     }
 
     public function testUpdate()
     {
         $mockUpdate = $this->getMockBuilder(Update::class)->disableOriginalConstructor()->getMock();
-        $this->assertSame($mockUpdate,
-            $this->object->setUpdate($mockUpdate)->getUpdate());
+        $this->assertSame($mockUpdate, $this->object->setUpdate($mockUpdate)->getUpdate());
     }
 
     public function testUpdateLazyLoad()

--- a/tests/src/Orm/Events/Validate/Schema/DefaultValueTest.php
+++ b/tests/src/Orm/Events/Validate/Schema/DefaultValueTest.php
@@ -70,23 +70,6 @@ class DefaultValueTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(HasDefaultValuesInterface::class, $this->object->getTypeInterface());
     }
 
-    public function testValidateNotCreate()
-    {
-        $data = ['id' => 1, 'name' => 'ted'];
-        $fields = ['id' => 999, 'name' => 'rupert', 'ack' => true];
-        $this->object->getModel()->setData($data);
-        $event = $this->getMockBuilder(Event::class)->getMock();
-        
-        $entity = $this->getMockBuilder(HasDefaultValuesInterface::class)->getMock();
-        $entity->expects($this->exactly(0))->method('getDefaultValues')->willReturn($fields);
-
-        $this->object->getModel()->expects($this->any())->method('getEntity')->willReturn($entity);
-        $event->expects($this->any())->method('getTarget')->willReturn($this->object->getModel());
-        $event->expects($this->any())->method('getParams')->willReturn(['events'=>[]]);
-        $this->object->onExecute($event);
-        $this->assertEquals($data, $this->object->getModel()->getData());
-    }
-
     public function testValidateGoldenPath()
     {
         $this->object->setParams(['events' => [ModelEvents::CREATE]]);
@@ -96,7 +79,7 @@ class DefaultValueTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($this->object->validate($data, $fields));
         $this->assertEquals($default, $this->object->getModel()->getData());
     }
-    
+
     public function testValidateAllValuesProvidedNoDefault()
     {
         $this->object->setParams(['events' => [ModelEvents::CREATE]]);
@@ -105,7 +88,7 @@ class DefaultValueTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($this->object->validate($data, $fields));
         $this->assertEquals($data, $this->object->getModel()->getData());
     }
-    
+
     public function testValidatePoorFormat()
     {
         $this->object->setParams(['events' => ModelEvents::CREATE]);
@@ -113,5 +96,4 @@ class DefaultValueTest extends PHPUnit_Framework_TestCase
         $fields = ['id' => 999, 'name' => 'rupert', 'ack' => true];
         $this->assertTrue($this->object->validate($data, $fields));
     }
-    
 }


### PR DESCRIPTION
#### Fixes
Fixes #25 

#### Changes proposed in this pull request:
-Removed ModelEvents::VALIDATE from crud model and from the enumerate
-Removed event logic from DefaultValue
-Updated events so event was easier to set
-Updated documentaiton to reflect event changes

#### Checklist
---- place an X confirming all items have been verified ----

[X]  Unit tests coverage exceeds or maintains current levels
[X]  Code Sniffer has reported zero issues (run command: ```composer inspect```)
[X]  Documentation is thorough and rich in content