### PR TITLE
Bug/83 pdo create id not setting

### DIFF
--- a/src/Orm/Events/Persistence/Pdo/Create.php
+++ b/src/Orm/Events/Persistence/Pdo/Create.php
@@ -37,11 +37,12 @@ class Create extends AbstractPdoEvent
             /* @var $model ModelInterface */
             $model = $event->getTarget();
             $entity = $model->getEntity();
-            $this->getCreate()
+            $idx = $this->getCreate()
                 ->setIsStrict()
                 ->setTable($entity->getTable())
                 ->setData($model->getData())
                 ->execute($this->getAdapter());
+            $model->setId($idx);
         } catch (NoRecordsAffectedException $exc) {
             throw new RecordNotFoundException();
         }

--- a/src/Orm/Events/Persistence/Pdo/Create.php
+++ b/src/Orm/Events/Persistence/Pdo/Create.php
@@ -46,6 +46,7 @@ class Create extends AbstractPdoEvent
         } catch (NoRecordsAffectedException $exc) {
             throw new RecordNotFoundException();
         }
+        return true;
     }
 
     /**

--- a/tests/src/Orm/Events/Persistence/Pdo/CreateTest.php
+++ b/tests/src/Orm/Events/Persistence/Pdo/CreateTest.php
@@ -29,7 +29,6 @@ class CreateTest extends TestCase
     protected function setUp()
     {
         $this->mockAdapter = $this->getMockBuilder(PDO::class)->disableOriginalConstructor()->getMock();
-        $this->mockAdapter->expects($this->any())->method('lastInsertId')->willReturn(1);
         $this->object = new Create([], $this->mockAdapter);
     }
 
@@ -76,19 +75,19 @@ class CreateTest extends TestCase
         $model = $this->getMockBuilder(ModelInterface::class)->getMock();
         $model->expects($this->once())->method('getEntity')->willReturn($entity);
         $model->expects($this->once())->method('getData')->willReturn($data);
-        $model->expects($this->once())->method('setId')->willReturn(1);
+        $model->expects($this->once())->method('setId')->with(1);
 
         $create = $this->getMockBuilder(CreateCommand::class)->disableOriginalConstructor()->getMock();
         $create->expects($this->once())->method('setIsStrict')->willReturnSelf();
         $create->expects($this->once())->method('setData')->with($data)->willReturnSelf();
         $create->expects($this->once())->method('setTable')->with($table)->willReturnSelf();
-        $create->expects($this->once())->method('execute')->with($this->mockAdapter);
+        $create->expects($this->once())->method('execute')->with($this->mockAdapter)->willReturn(1);
 
 
         $event = $this->getMockBuilder(EventInterface::class)->getMock();
         $event->expects($this->exactly(2))->method('getTarget')->willReturn($model);
 
-        $this->assertNull($this->object->setCreate($create)->onExecute($event));
+        $this->assertTrue($this->object->setCreate($create)->onExecute($event));
     }
 
     public function testOnExecuteNoRecord()

--- a/tests/src/Orm/Events/Persistence/Pdo/CreateTest.php
+++ b/tests/src/Orm/Events/Persistence/Pdo/CreateTest.php
@@ -29,6 +29,7 @@ class CreateTest extends TestCase
     protected function setUp()
     {
         $this->mockAdapter = $this->getMockBuilder(PDO::class)->disableOriginalConstructor()->getMock();
+        $this->mockAdapter->expects($this->any())->method('lastInsertId')->willReturn(1);
         $this->object = new Create([], $this->mockAdapter);
     }
 
@@ -75,6 +76,7 @@ class CreateTest extends TestCase
         $model = $this->getMockBuilder(ModelInterface::class)->getMock();
         $model->expects($this->once())->method('getEntity')->willReturn($entity);
         $model->expects($this->once())->method('getData')->willReturn($data);
+        $model->expects($this->once())->method('setId')->willReturn(1);
 
         $create = $this->getMockBuilder(CreateCommand::class)->disableOriginalConstructor()->getMock();
         $create->expects($this->once())->method('setIsStrict')->willReturnSelf();


### PR DESCRIPTION
#### Fixes
Fixes #83 

#### Changes proposed in this pull request:
-When a record is created ID should be set in the model.

#### Checklist
*place an x confirming all items have been verified*
- [x]  Unit tests coverage exceeds or maintains current levels (run command: ```composer test```)
- [x]  Code Sniffer has reported zero issues (run command: ```composer inspect```)
- [x]  Documentation is thorough and rich in content
