### PR TITLE
Add an error event to report error to user

### DIFF
--- a/src/Orm/CrudModel.php
+++ b/src/Orm/CrudModel.php
@@ -46,10 +46,10 @@ class CrudModel extends Model
         try {
             $this->setData($data);
             $this->getEventManager()->trigger(ModelEvents::CREATE, $this);
-            return $this->getData();
         } catch (\Exception $exc) {
             $this->manageExceptions($exc, ModelEvents::CREATE);
         }
+        return $this->getData();
     }
 
     /**
@@ -63,10 +63,10 @@ class CrudModel extends Model
         try {
             $this->setId($idx);
             $this->getEventManager()->trigger(ModelEvents::FETCH, $this);
-            return $this->getData();
         } catch (\Exception $exc) {
             $this->manageExceptions($exc, ModelEvents::FETCH);
         }
+        return $this->getData();
     }
 
     /**
@@ -78,10 +78,10 @@ class CrudModel extends Model
     {
         try {
             $this->getEventManager()->trigger(ModelEvents::FETCH_ALL, $this);
-            return $this->getData();
         } catch (Exception $exc) {
             $this->manageExceptions($exc, ModelEvents::FETCH_ALL);
         }
+        return $this->getData();
     }
 
     /**
@@ -96,10 +96,10 @@ class CrudModel extends Model
         try {
             $this->setId($idx)->setData($data);
             $this->getEventManager()->trigger(ModelEvents::UPDATE, $this);
-            return $this->getData();
         } catch (Exception $exc) {
             $this->manageExceptions($exc, ModelEvents::UPDATE);
         }
+        return $this->getData();
     }
 
     /**
@@ -116,6 +116,7 @@ class CrudModel extends Model
             return true;
         } catch (Exception $exc) {
             $this->manageExceptions($exc, ModelEvents::DELETE);
+            return false;
         }
     }
 

--- a/src/Orm/Events/Logger/ErrorLog.php
+++ b/src/Orm/Events/Logger/ErrorLog.php
@@ -1,0 +1,62 @@
+<?php
+/*
+ * The MIT License
+ *
+ * Copyright 2017 David Schoenbauer.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+namespace DSchoenbauer\Orm\Events\Logger;
+
+use DSchoenbauer\Orm\Events\AbstractEvent;
+use DSchoenbauer\Orm\Framework\InterpolateTrait;
+use DSchoenbauer\Orm\ModelInterface;
+use Exception;
+use Zend\EventManager\EventInterface;
+
+/**
+ * Description of ErrorLog
+ *
+ * @author David Schoenbauer
+ */
+class ErrorLog extends AbstractEvent
+{
+
+    const KEY_SUCCESS = 'success';
+    const KEY_EVENT = 'event';
+    const KEY_MESSAGE = 'message';
+
+    use InterpolateTrait;
+
+    public function onExecute(EventInterface $event)
+    {
+        $model = $event->getTarget();
+        $exception = $event->getParam('exception', null);
+        $event = $event->getParam('event', null);
+        if (!$model instanceof ModelInterface || !$exception instanceof Exception) {
+            return false;
+        }
+        $model->setData([
+            self::KEY_SUCCESS => false,
+            self::KEY_EVENT => $event,
+            self::KEY_MESSAGE => $exception->getMessage(),
+        ]);
+        return true;
+    }
+}

--- a/tests/src/Orm/Events/Logger/ErrorLogTest.php
+++ b/tests/src/Orm/Events/Logger/ErrorLogTest.php
@@ -1,0 +1,81 @@
+<?php
+/*
+ * The MIT License
+ *
+ * Copyright 2017 David Schoenbauer.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+namespace DSchoenbauer\Orm\Events\Logger;
+
+use DSchoenbauer\Orm\Events\AbstractEvent;
+use DSchoenbauer\Tests\Orm\Events\Persistence\Http\TestModelTrait;
+use PHPUnit\Framework\TestCase;
+use Zend\EventManager\EventInterface;
+
+/**
+ * Description of LoggerClass
+ *
+ * @author David Schoenbauer
+ */
+class ErrorLogTest extends TestCase
+{
+
+    private $object;
+
+    use TestModelTrait;
+
+    protected function setUp()
+    {
+        $this->object = new ErrorLog();
+    }
+
+    public function testIsAbstractEvent()
+    {
+        $this->assertInstanceOf(AbstractEvent::class, $this->object);
+    }
+
+    public function testOnExecuteNoTarget()
+    {
+        $event = $this->getMockBuilder(EventInterface::class)->getMock();
+        $this->assertFalse($this->object->onExecute($event));
+    }
+
+    public function testOnExecuteNoException()
+    {
+        $event = $this->getMockBuilder(EventInterface::class)->getMock();
+        $event->expects($this->any())->method('getTarget')->willReturn($this->getModel());
+        $this->assertFalse($this->object->onExecute($event));
+    }
+
+    public function testOnExecuteGood()
+    {
+        $event = $this->getMockBuilder(EventInterface::class)->getMock();
+        $model = $this->getModel();
+        $event->expects($this->any())->method('getTarget')->willReturn($model);
+        $event->expects($this->any())->method('getParam')->willReturnOnConsecutiveCalls(new \Exception('message'), "eventName");
+        $data = [
+            'success' => false,
+            'event' => 'eventName',
+            'message' => 'message',
+        ];
+        $this->assertTrue($this->object->onExecute($event));
+        $this->assertEquals($data, $model->getData());
+    }
+}


### PR DESCRIPTION
Error event the will capture and report all exceptions

#### Fixes
Fixes #84 

#### Changes proposed in this pull request:
-Adds new event that will capture and report exceptions


#### Checklist
*place an x confirming all items have been verified*
- [x]  Unit tests coverage exceeds or maintains current levels (run command: ```composer test```)
- [x]  Code Sniffer has reported zero issues (run command: ```composer inspect```)
- [x]  Documentation is thorough and rich in content
