### PR TITLE
Feature/91 normalize model validation

### DIFF
--- a/src/Orm/Events/Filter/MassMapper.php
+++ b/src/Orm/Events/Filter/MassMapper.php
@@ -56,13 +56,10 @@ class MassMapper extends AbstractEvent
     public function onExecute(EventInterface $event)
     {
         $model = $event->getTarget();
-        if (!$model instanceof ModelInterface) {
+        if (!$this->validateModel($model, MassMappingInterface::class)) {
             return false;
         }
         $entity = $model->getEntity();
-        if (!$entity instanceof MassMappingInterface) {
-            return false;
-        }
         $model->setData($this->mapData($entity->getMapping(), $model->getData()));
         return true;
     }

--- a/src/Orm/Events/Filter/RemoveId.php
+++ b/src/Orm/Events/Filter/RemoveId.php
@@ -24,6 +24,7 @@
  */
 namespace DSchoenbauer\Orm\Events\Filter;
 
+use DSchoenbauer\Orm\Entity\EntityInterface;
 use DSchoenbauer\Orm\Events\AbstractEvent;
 use DSchoenbauer\Orm\ModelInterface;
 use Zend\EventManager\EventInterface;
@@ -40,7 +41,7 @@ class RemoveId extends AbstractEvent
     {
         /* @var $model ModelInterface */
         $model = $event->getTarget();
-        if (!$model instanceof ModelInterface) {
+        if (!$this->validateModel($model, EntityInterface::class)) {
             return false;
         }
         $data = $model->getData();

--- a/src/Orm/Events/Persistence/File/AbstractFileEvent.php
+++ b/src/Orm/Events/Persistence/File/AbstractFileEvent.php
@@ -105,13 +105,11 @@ abstract class AbstractFileEvent extends AbstractEvent
 
     public function onExecute(EventInterface $event)
     {
-        if (!$event->getTarget() instanceof ModelInterface ||
-            !$event->getTarget()->getEntity() instanceof EntityInterface
-        ) {
+        $model = $event->getTarget();
+        if (!$this->validateModel($model, EntityInterface::class)) {
             return false; //Nothing to do with this event
         }
         /* @var $model ModelInterface */
-        $model = $event->getTarget();
         $existingData = $this->loadFile($model->getEntity());
         return $this->processAction($model, $existingData);
     }

--- a/src/Orm/Events/Persistence/Http/AbstractHttpEvent.php
+++ b/src/Orm/Events/Persistence/Http/AbstractHttpEvent.php
@@ -89,12 +89,7 @@ abstract class AbstractHttpEvent extends AbstractEvent
     {
         /* @var $model ModelInterface */
         $model = $event->getTarget();
-        if (!$model instanceof ModelInterface) {
-            return;
-        }
-        /* @var $entity IsHttp */
-        $entity = $model->getEntity();
-        if (!$entity instanceof EntityInterface || !$entity instanceof IsHttpInterface) {
+        if (!$this->validateModel($model, IsHttpInterface::class)) {
             return;
         }
         $this->run($model);

--- a/src/Orm/Events/Persistence/Pdo/AbstractPdoEvent.php
+++ b/src/Orm/Events/Persistence/Pdo/AbstractPdoEvent.php
@@ -24,9 +24,11 @@
  */
 namespace DSchoenbauer\Orm\Events\Persistence\Pdo;
 
+use DSchoenbauer\Orm\Entity\EntityInterface;
 use DSchoenbauer\Orm\Enum\EventPriorities;
 use DSchoenbauer\Orm\Events\AbstractEvent;
 use PDO;
+use Zend\EventManager\EventInterface;
 
 /**
  * Description of AbstractPdoEvent
@@ -48,10 +50,19 @@ abstract class AbstractPdoEvent extends AbstractEvent
     public function __construct(array $events, PDO $adapter, $priority = EventPriorities::ON_TIME)
     {
 
-
         parent::__construct($events, $priority);
         $this->setAdapter($adapter);
     }
+
+    public function onExecute(EventInterface $event)
+    {
+        if (!$this->validateModel($event->getTarget(), EntityInterface::class)) {
+            return;
+        }
+        return $this->commit($event);
+    }
+
+    abstract protected function commit(EventInterface $event);
 
     /**
      * Returns a PHP Data Object

--- a/src/Orm/Events/Persistence/Pdo/Create.php
+++ b/src/Orm/Events/Persistence/Pdo/Create.php
@@ -6,6 +6,7 @@
  */
 namespace DSchoenbauer\Orm\Events\Persistence\Pdo;
 
+use DSchoenbauer\Orm\Entity\EntityInterface;
 use DSchoenbauer\Orm\Exception\RecordNotFoundException;
 use DSchoenbauer\Orm\ModelInterface;
 use DSchoenbauer\Sql\Command\Create as CreateCommand;
@@ -28,11 +29,8 @@ class Create extends AbstractPdoEvent
      * @return void
      * @since v1.0.0
      */
-    public function onExecute(EventInterface $event)
+    public function commit(EventInterface $event)
     {
-        if (!$event->getTarget() instanceof ModelInterface) {
-            return;
-        }
         try {
             /* @var $model ModelInterface */
             $model = $event->getTarget();

--- a/src/Orm/Events/Persistence/Pdo/Delete.php
+++ b/src/Orm/Events/Persistence/Pdo/Delete.php
@@ -6,6 +6,7 @@
  */
 namespace DSchoenbauer\Orm\Events\Persistence\Pdo;
 
+use DSchoenbauer\Orm\Entity\EntityInterface;
 use DSchoenbauer\Orm\Exception\RecordNotFoundException;
 use DSchoenbauer\Orm\ModelInterface;
 use DSchoenbauer\Sql\Command\Delete as DeleteCommand;
@@ -29,11 +30,8 @@ class Delete extends AbstractPdoEvent
      * @return void
      * @since v1.0.0
      */
-    public function onExecute(EventInterface $event)
+    public function commit(EventInterface $event)
     {
-        if (!$event->getTarget() instanceof ModelInterface) {
-            return;
-        }
         try {
             /* @var $model ModelInterface */
             $model = $event->getTarget();

--- a/src/Orm/Events/Persistence/Pdo/Select.php
+++ b/src/Orm/Events/Persistence/Pdo/Select.php
@@ -24,6 +24,7 @@
  */
 namespace DSchoenbauer\Orm\Events\Persistence\Pdo;
 
+use DSchoenbauer\Orm\Entity\EntityInterface;
 use DSchoenbauer\Orm\Exception\RecordNotFoundException;
 use DSchoenbauer\Orm\ModelInterface;
 use DSchoenbauer\Sql\Command\Select as SelectCommand;
@@ -47,11 +48,8 @@ class Select extends AbstractPdoEvent
      * @return void
      * @since v1.0.0
      */
-    public function onExecute(EventInterface $event)
+    public function commit(EventInterface $event)
     {
-        if (!$event->getTarget() instanceof ModelInterface) {
-            return; //Nothing to do with this event
-        }
         try {
             /* @var $model ModelInterface */
             $model = $event->getTarget();

--- a/src/Orm/Events/Persistence/Pdo/Update.php
+++ b/src/Orm/Events/Persistence/Pdo/Update.php
@@ -6,6 +6,7 @@
  */
 namespace DSchoenbauer\Orm\Events\Persistence\Pdo;
 
+use DSchoenbauer\Orm\Entity\EntityInterface;
 use DSchoenbauer\Orm\Exception\RecordNotFoundException;
 use DSchoenbauer\Orm\ModelInterface;
 use DSchoenbauer\Sql\Command\Update as UpdateCommand;
@@ -29,11 +30,8 @@ class Update extends AbstractPdoEvent
      * @return void
      * @since v1.0.0
      */
-    public function onExecute(EventInterface $event)
+    public function commit(EventInterface $event)
     {
-        if (!$event->getTarget() instanceof ModelInterface) {
-            return;
-        }
         try {
             /* @var $model ModelInterface */
             $model = $event->getTarget();

--- a/src/Orm/Events/Validate/AbstractValidate.php
+++ b/src/Orm/Events/Validate/AbstractValidate.php
@@ -65,21 +65,19 @@ abstract class AbstractValidate extends AbstractEvent
      */
     public function onExecute(EventInterface $event)
     {
-        if (!$event->getTarget() instanceof ModelInterface) {
+        $model = $event->getTarget();
+        if (!$this->validateModel($model, $this->getTypeInterface())) {
             return;
         }
-        $this->setModel($event->getTarget());
-        $this->setParams($event->getParams());
+        $this
+            ->setModel($model)
+            ->setParams($event->getParams());
 
-        $entity = $this->getModel()->getEntity();
-        if (!is_a($entity, $this->getTypeInterface())) {
-            return;
-        }
         if (!$this->preExecuteCheck()) {
             return;
         }
 
-        $this->validate($this->getModel()->getData(), $this->getFields($entity));
+        $this->validate($model->getData(), $this->getFields($model->getEntity()));
     }
 
     /**

--- a/tests/src/Orm/Events/Filter/RemoveIdTest.php
+++ b/tests/src/Orm/Events/Filter/RemoveIdTest.php
@@ -76,21 +76,21 @@ class RemoveIdTest extends TestCase
     {
 
         $entity = $this->getMockBuilder(EntityInterface::class)->getMock();
-        $entity->expects($this->once())->method('getIdField')->willReturn($idField);
+        $entity->expects($this->any())->method('getIdField')->willReturn($idField);
 
         $model = $this->getMockBuilder(ModelInterface::class)->getMock();
-        $model->expects($this->exactly(1))->method('getEntity')->willReturn($entity);
-        $model->expects($this->exactly(2))->method('setData')->willReturnCallback(function($data) {
+        $model->expects($this->any())->method('getEntity')->willReturn($entity);
+        $model->expects($this->any())->method('setData')->willReturnCallback(function($data) {
             $this->data = $data;
             return $this;
         });
-        $model->expects($this->exactly(2))->method('getData')->willReturnCallback(function() {
+        $model->expects($this->any())->method('getData')->willReturnCallback(function() {
             return $this->data;
         });
         $model->setData($data);
 
         $event = $this->getMockBuilder(EventInterface::class)->getMock();
-        $event->expects($this->exactly(1))->method('getTarget')->willReturn($model);
+        $event->expects($this->any())->method('getTarget')->willReturn($model);
 
         $this->assertTrue($this->object->onExecute($event));
         $this->assertEquals($result, $model->getData());

--- a/tests/src/Orm/Events/Persistence/Pdo/CreateTest.php
+++ b/tests/src/Orm/Events/Persistence/Pdo/CreateTest.php
@@ -57,7 +57,7 @@ class CreateTest extends TestCase
     public function testOnExecuteTargetNotModel()
     {
         $event = $this->getMockBuilder(EventInterface::class)->getMock();
-        $event->expects($this->once())
+        $event->expects($this->any())
             ->method('getTarget')
             ->willReturn(null);
         $this->assertNull($this->object->onExecute($event));
@@ -70,22 +70,22 @@ class CreateTest extends TestCase
         $data = ['test' => 1, 'some_id' => 2];
 
         $entity = $this->getMockBuilder(EntityInterface::class)->getMock();
-        $entity->expects($this->once())->method('getTable')->willReturn($table);
+        $entity->expects($this->any())->method('getTable')->willReturn($table);
 
         $model = $this->getMockBuilder(ModelInterface::class)->getMock();
-        $model->expects($this->once())->method('getEntity')->willReturn($entity);
-        $model->expects($this->once())->method('getData')->willReturn($data);
-        $model->expects($this->once())->method('setId')->with(1);
+        $model->expects($this->any())->method('getEntity')->willReturn($entity);
+        $model->expects($this->any())->method('getData')->willReturn($data);
+        $model->expects($this->any())->method('setId')->with(1);
 
         $create = $this->getMockBuilder(CreateCommand::class)->disableOriginalConstructor()->getMock();
-        $create->expects($this->once())->method('setIsStrict')->willReturnSelf();
-        $create->expects($this->once())->method('setData')->with($data)->willReturnSelf();
-        $create->expects($this->once())->method('setTable')->with($table)->willReturnSelf();
-        $create->expects($this->once())->method('execute')->with($this->mockAdapter)->willReturn(1);
+        $create->expects($this->any())->method('setIsStrict')->willReturnSelf();
+        $create->expects($this->any())->method('setData')->with($data)->willReturnSelf();
+        $create->expects($this->any())->method('setTable')->with($table)->willReturnSelf();
+        $create->expects($this->any())->method('execute')->with($this->mockAdapter)->willReturn(1);
 
 
         $event = $this->getMockBuilder(EventInterface::class)->getMock();
-        $event->expects($this->exactly(2))->method('getTarget')->willReturn($model);
+        $event->expects($this->any())->method('getTarget')->willReturn($model);
 
         $this->assertTrue($this->object->setCreate($create)->onExecute($event));
     }
@@ -98,21 +98,21 @@ class CreateTest extends TestCase
 
         $this->expectException(RecordNotFoundException::class);
         $entity = $this->getMockBuilder(EntityInterface::class)->getMock();
-        $entity->expects($this->once())->method('getTable')->willReturn($table);
+        $entity->expects($this->any())->method('getTable')->willReturn($table);
 
         $model = $this->getMockBuilder(ModelInterface::class)->getMock();
-        $model->expects($this->once())->method('getEntity')->willReturn($entity);
-        $model->expects($this->once())->method('getData')->willReturn($data);
+        $model->expects($this->any())->method('getEntity')->willReturn($entity);
+        $model->expects($this->any())->method('getData')->willReturn($data);
 
         $create = $this->getMockBuilder(CreateCommand::class)->disableOriginalConstructor()->getMock();
-        $create->expects($this->once())->method('setIsStrict')->willReturnSelf();
-        $create->expects($this->once())->method('setData')->with($data)->willReturnSelf();
-        $create->expects($this->once())->method('setTable')->with($table)->willReturnSelf();
-        $create->expects($this->once())->method('execute')->with($this->mockAdapter)->willThrowException(new NoRecordsAffectedCreateException());
+        $create->expects($this->any())->method('setIsStrict')->willReturnSelf();
+        $create->expects($this->any())->method('setData')->with($data)->willReturnSelf();
+        $create->expects($this->any())->method('setTable')->with($table)->willReturnSelf();
+        $create->expects($this->any())->method('execute')->with($this->mockAdapter)->willThrowException(new NoRecordsAffectedCreateException());
 
 
         $event = $this->getMockBuilder(EventInterface::class)->getMock();
-        $event->expects($this->exactly(2))->method('getTarget')->willReturn($model);
+        $event->expects($this->any())->method('getTarget')->willReturn($model);
 
         $this->object->setCreate($create)->onExecute($event);
     }

--- a/tests/src/Orm/Events/Persistence/Pdo/DeleteTest.php
+++ b/tests/src/Orm/Events/Persistence/Pdo/DeleteTest.php
@@ -56,7 +56,7 @@ class DeleteTest extends TestCase
     public function testOnExecuteTargetNotModel()
     {
         $event = $this->getMockBuilder(EventInterface::class)->getMock();
-        $event->expects($this->once())
+        $event->expects($this->any())
             ->method('getTarget')
             ->willReturn(null);
         $this->assertNull($this->object->onExecute($event));
@@ -68,22 +68,22 @@ class DeleteTest extends TestCase
         $idField = "id";
 
         $entity = $this->getMockBuilder(EntityInterface::class)->getMock();
-        $entity->expects($this->once())->method('getTable')->willReturn($table);
-        $entity->expects($this->once())->method('getIdField')->willReturn($idField);
+        $entity->expects($this->any())->method('getTable')->willReturn($table);
+        $entity->expects($this->any())->method('getIdField')->willReturn($idField);
 
         $model = $this->getMockBuilder(ModelInterface::class)->getMock();
-        $model->expects($this->once())->method('getEntity')->willReturn($entity);
-        $model->expects($this->once())->method('getId')->willReturn(1);
+        $model->expects($this->any())->method('getEntity')->willReturn($entity);
+        $model->expects($this->any())->method('getId')->willReturn(1);
 
         $delete = $this->getMockBuilder(DeleteCommand::class)->disableOriginalConstructor()->getMock();
-        $delete->expects($this->once())->method('setIsStrict')->willReturnSelf();
-        $delete->expects($this->once())->method('setTable')->with($table)->willReturnSelf();
-        $delete->expects($this->once())->method('setWhere')->willReturnSelf();
-        $delete->expects($this->once())->method('execute')->with($this->mockAdapter);
+        $delete->expects($this->any())->method('setIsStrict')->willReturnSelf();
+        $delete->expects($this->any())->method('setTable')->with($table)->willReturnSelf();
+        $delete->expects($this->any())->method('setWhere')->willReturnSelf();
+        $delete->expects($this->any())->method('execute')->with($this->mockAdapter);
 
 
         $event = $this->getMockBuilder(EventInterface::class)->getMock();
-        $event->expects($this->exactly(2))->method('getTarget')->willReturn($model);
+        $event->expects($this->any())->method('getTarget')->willReturn($model);
 
         $this->assertNull($this->object->setDelete($delete)->onExecute($event));
     }
@@ -96,22 +96,22 @@ class DeleteTest extends TestCase
         $this->expectException(\DSchoenbauer\Orm\Exception\RecordNotFoundException::class);
         
         $entity = $this->getMockBuilder(EntityInterface::class)->getMock();
-        $entity->expects($this->once())->method('getTable')->willReturn($table);
-        $entity->expects($this->once())->method('getIdField')->willReturn($idField);
+        $entity->expects($this->any())->method('getTable')->willReturn($table);
+        $entity->expects($this->any())->method('getIdField')->willReturn($idField);
 
         $model = $this->getMockBuilder(ModelInterface::class)->getMock();
-        $model->expects($this->once())->method('getEntity')->willReturn($entity);
-        $model->expects($this->once())->method('getId')->willReturn(1);
+        $model->expects($this->any())->method('getEntity')->willReturn($entity);
+        $model->expects($this->any())->method('getId')->willReturn(1);
 
         $delete = $this->getMockBuilder(DeleteCommand::class)->disableOriginalConstructor()->getMock();
-        $delete->expects($this->once())->method('setIsStrict')->willReturnSelf();
-        $delete->expects($this->once())->method('setTable')->with($table)->willReturnSelf();
-        $delete->expects($this->once())->method('setWhere')->willReturnSelf();
-        $delete->expects($this->once())->method('execute')->with($this->mockAdapter)->willThrowException(new NoRecordsAffectedCreateException());
+        $delete->expects($this->any())->method('setIsStrict')->willReturnSelf();
+        $delete->expects($this->any())->method('setTable')->with($table)->willReturnSelf();
+        $delete->expects($this->any())->method('setWhere')->willReturnSelf();
+        $delete->expects($this->any())->method('execute')->with($this->mockAdapter)->willThrowException(new NoRecordsAffectedCreateException());
 
 
         $event = $this->getMockBuilder(EventInterface::class)->getMock();
-        $event->expects($this->exactly(2))->method('getTarget')->willReturn($model);
+        $event->expects($this->any())->method('getTarget')->willReturn($model);
 
         $this->object->setDelete($delete)->onExecute($event);
     }

--- a/tests/src/Orm/Events/Persistence/Pdo/SelectTest.php
+++ b/tests/src/Orm/Events/Persistence/Pdo/SelectTest.php
@@ -76,7 +76,7 @@ class SelectTest extends TestCase
     public function testOnExecuteTargetNotModel()
     {
         $event = $this->getMockBuilder(EventInterface::class)->getMock();
-        $event->expects($this->once())
+        $event->expects($this->any())
             ->method('getTarget')
             ->willReturn(null);
         $this->assertNull($this->object->onExecute($event));
@@ -89,26 +89,26 @@ class SelectTest extends TestCase
         $idField = "id";
 
         $model = $this->getMockBuilder(ModelInterface::class)->getMock();
-        $model->expects($this->once())->method('getId')->willReturn(1);
+        $model->expects($this->any())->method('getId')->willReturn(1);
 
         $entity = $this->getMockBuilder(EntityInterface::class)->getMock();
-        $entity->expects($this->once())->method('getTable')->willReturn($table);
-        $entity->expects($this->once())->method('getAllFields')->willReturn($fields);
-        $entity->expects($this->once())->method('getIdField')->willReturn($idField);
+        $entity->expects($this->any())->method('getTable')->willReturn($table);
+        $entity->expects($this->any())->method('getAllFields')->willReturn($fields);
+        $entity->expects($this->any())->method('getIdField')->willReturn($idField);
 
         $select = $this->getMockBuilder(SelectCommand::class)->disableOriginalConstructor()->getMock();
-        $select->expects($this->once())->method('setIsStrict')->willReturnSelf();
-        $select->expects($this->once())->method('setTable')->with($table)->willReturnSelf();
-        $select->expects($this->once())->method('setFields')->with($fields)->willReturnSelf();
-        $select->expects($this->once())->method('setWhere')->willReturnSelf();
-        $select->expects($this->once())->method('setFetchFlat')->willReturnSelf();
-        $select->expects($this->once())->method('execute')->with($this->mockAdapter);
+        $select->expects($this->any())->method('setIsStrict')->willReturnSelf();
+        $select->expects($this->any())->method('setTable')->with($table)->willReturnSelf();
+        $select->expects($this->any())->method('setFields')->with($fields)->willReturnSelf();
+        $select->expects($this->any())->method('setWhere')->willReturnSelf();
+        $select->expects($this->any())->method('setFetchFlat')->willReturnSelf();
+        $select->expects($this->any())->method('execute')->with($this->mockAdapter);
 
 
-        $model->expects($this->once())->method('getEntity')->willReturn($entity);
+        $model->expects($this->any())->method('getEntity')->willReturn($entity);
 
         $event = $this->getMockBuilder(EventInterface::class)->getMock();
-        $event->expects($this->exactly(2))->method('getTarget')->willReturn($model);
+        $event->expects($this->any())->method('getTarget')->willReturn($model);
 
         $this->assertNull($this->object->setSelect($select)->onExecute($event));
     }
@@ -121,26 +121,26 @@ class SelectTest extends TestCase
 
         $this->expectException(RecordNotFoundException::class);
         $model = $this->getMockBuilder(ModelInterface::class)->getMock();
-        $model->expects($this->once())->method('getId')->willReturn(1);
+        $model->expects($this->any())->method('getId')->willReturn(1);
 
         $entity = $this->getMockBuilder(EntityInterface::class)->getMock();
-        $entity->expects($this->once())->method('getTable')->willReturn($table);
-        $entity->expects($this->once())->method('getAllFields')->willReturn($fields);
-        $entity->expects($this->once())->method('getIdField')->willReturn($idField);
+        $entity->expects($this->any())->method('getTable')->willReturn($table);
+        $entity->expects($this->any())->method('getAllFields')->willReturn($fields);
+        $entity->expects($this->any())->method('getIdField')->willReturn($idField);
 
         $select = $this->getMockBuilder(SelectCommand::class)->disableOriginalConstructor()->getMock();
-        $select->expects($this->once())->method('setIsStrict')->willReturnSelf();
-        $select->expects($this->once())->method('setTable')->with($table)->willReturnSelf();
-        $select->expects($this->once())->method('setFields')->with($fields)->willReturnSelf();
-        $select->expects($this->once())->method('setWhere')->willReturnSelf();
-        $select->expects($this->once())->method('setFetchFlat')->willReturnSelf();
-        $select->expects($this->once())->method('execute')->with($this->mockAdapter)->willThrowException(new NoRecordsAffectedException());
+        $select->expects($this->any())->method('setIsStrict')->willReturnSelf();
+        $select->expects($this->any())->method('setTable')->with($table)->willReturnSelf();
+        $select->expects($this->any())->method('setFields')->with($fields)->willReturnSelf();
+        $select->expects($this->any())->method('setWhere')->willReturnSelf();
+        $select->expects($this->any())->method('setFetchFlat')->willReturnSelf();
+        $select->expects($this->any())->method('execute')->with($this->mockAdapter)->willThrowException(new NoRecordsAffectedException());
 
 
-        $model->expects($this->once())->method('getEntity')->willReturn($entity);
+        $model->expects($this->any())->method('getEntity')->willReturn($entity);
 
         $event = $this->getMockBuilder(EventInterface::class)->getMock();
-        $event->expects($this->exactly(2))->method('getTarget')->willReturn($model);
+        $event->expects($this->any())->method('getTarget')->willReturn($model);
 
         $this->object->setSelect($select)->onExecute($event);
     }

--- a/tests/src/Orm/Events/Persistence/Pdo/UpdateTest.php
+++ b/tests/src/Orm/Events/Persistence/Pdo/UpdateTest.php
@@ -57,7 +57,7 @@ class UpdateTest extends TestCase
     public function testOnExecuteTargetNotModel()
     {
         $event = $this->getMockBuilder(EventInterface::class)->getMock();
-        $event->expects($this->once())
+        $event->expects($this->any())
             ->method('getTarget')
             ->willReturn(null);
         $this->assertNull($this->object->onExecute($event));
@@ -70,24 +70,24 @@ class UpdateTest extends TestCase
         $idField = "id";
 
         $entity = $this->getMockBuilder(EntityInterface::class)->getMock();
-        $entity->expects($this->once())->method('getTable')->willReturn($table);
-        $entity->expects($this->once())->method('getIdField')->willReturn($idField);
+        $entity->expects($this->any())->method('getTable')->willReturn($table);
+        $entity->expects($this->any())->method('getIdField')->willReturn($idField);
 
         $model = $this->getMockBuilder(ModelInterface::class)->getMock();
-        $model->expects($this->once())->method('getEntity')->willReturn($entity);
-        $model->expects($this->once())->method('getId')->willReturn(1);
-        $model->expects($this->once())->method('getData')->willReturn($data);
+        $model->expects($this->any())->method('getEntity')->willReturn($entity);
+        $model->expects($this->any())->method('getId')->willReturn(1);
+        $model->expects($this->any())->method('getData')->willReturn($data);
 
         $select = $this->getMockBuilder(UpdateCommand::class)->disableOriginalConstructor()->getMock();
-        $select->expects($this->once())->method('setIsStrict')->willReturnSelf();
-        $select->expects($this->once())->method('setTable')->with($table)->willReturnSelf();
-        $select->expects($this->once())->method('setData')->with($data)->willReturnSelf();
-        $select->expects($this->once())->method('setWhere')->willReturnSelf();
-        $select->expects($this->once())->method('execute')->with($this->mockAdapter);
+        $select->expects($this->any())->method('setIsStrict')->willReturnSelf();
+        $select->expects($this->any())->method('setTable')->with($table)->willReturnSelf();
+        $select->expects($this->any())->method('setData')->with($data)->willReturnSelf();
+        $select->expects($this->any())->method('setWhere')->willReturnSelf();
+        $select->expects($this->any())->method('execute')->with($this->mockAdapter);
 
 
         $event = $this->getMockBuilder(EventInterface::class)->getMock();
-        $event->expects($this->exactly(2))->method('getTarget')->willReturn($model);
+        $event->expects($this->any())->method('getTarget')->willReturn($model);
 
         $this->assertNull($this->object->setUpdate($select)->onExecute($event));
     }
@@ -100,24 +100,24 @@ class UpdateTest extends TestCase
         
         $this->expectException(RecordNotFoundException::class);
         $entity = $this->getMockBuilder(EntityInterface::class)->getMock();
-        $entity->expects($this->once())->method('getTable')->willReturn($table);
-        $entity->expects($this->once())->method('getIdField')->willReturn($idField);
+        $entity->expects($this->any())->method('getTable')->willReturn($table);
+        $entity->expects($this->any())->method('getIdField')->willReturn($idField);
 
         $model = $this->getMockBuilder(ModelInterface::class)->getMock();
-        $model->expects($this->once())->method('getEntity')->willReturn($entity);
-        $model->expects($this->once())->method('getId')->willReturn(1);
-        $model->expects($this->once())->method('getData')->willReturn($data);
+        $model->expects($this->any())->method('getEntity')->willReturn($entity);
+        $model->expects($this->any())->method('getId')->willReturn(1);
+        $model->expects($this->any())->method('getData')->willReturn($data);
 
         $select = $this->getMockBuilder(UpdateCommand::class)->disableOriginalConstructor()->getMock();
-        $select->expects($this->once())->method('setIsStrict')->willReturnSelf();
-        $select->expects($this->once())->method('setTable')->with($table)->willReturnSelf();
-        $select->expects($this->once())->method('setData')->with($data)->willReturnSelf();
-        $select->expects($this->once())->method('setWhere')->willReturnSelf();
-        $select->expects($this->once())->method('execute')->with($this->mockAdapter)->willThrowException(new NoRecordsAffectedException());
+        $select->expects($this->any())->method('setIsStrict')->willReturnSelf();
+        $select->expects($this->any())->method('setTable')->with($table)->willReturnSelf();
+        $select->expects($this->any())->method('setData')->with($data)->willReturnSelf();
+        $select->expects($this->any())->method('setWhere')->willReturnSelf();
+        $select->expects($this->any())->method('execute')->with($this->mockAdapter)->willThrowException(new NoRecordsAffectedException());
 
 
         $event = $this->getMockBuilder(EventInterface::class)->getMock();
-        $event->expects($this->exactly(2))->method('getTarget')->willReturn($model);
+        $event->expects($this->any())->method('getTarget')->willReturn($model);
 
         $this->object->setUpdate($select)->onExecute($event);
     }

--- a/tests/src/Orm/Events/Validate/AbstractValidateTest.php
+++ b/tests/src/Orm/Events/Validate/AbstractValidateTest.php
@@ -59,10 +59,10 @@ class AbstractValidateTest extends TestCase
         $entity = $this->getMockBuilder(EntityInterface::class)->getMock();
 
         $model = $this->getMockBuilder(ModelInterface::class)->getMock();
-        $model->expects($this->exactly(1))->method('getEntity')->willReturn($entity);
+        $model->expects($this->any())->method('getEntity')->willReturn($entity);
 
         $event = $this->getMockBuilder(EventInterface::class)->getMock();
-        $event->expects($this->exactly(2))->method('getTarget')->willReturn($model);
+        $event->expects($this->any())->method('getTarget')->willReturn($model);
 
         $this->assertNull($this->object->onExecute($event));
     }
@@ -74,16 +74,16 @@ class AbstractValidateTest extends TestCase
             ->setMethods(['preExecuteCheck'])
             ->getMockForAbstractClass();
 
-        $mock->expects($this->exactly(1))->method('preExecuteCheck')->willReturn(false);
+        $mock->expects($this->any())->method('preExecuteCheck')->willReturn(false);
         $mock->expects($this->once())->method('getTypeInterface')->willReturn(HasBoolFieldsInterface::class);
 
         $entity = $this->getMockBuilder(AbstractEntityWithBool::class)->getMock();
 
         $model = $this->getMockBuilder(ModelInterface::class)->getMock();
-        $model->expects($this->exactly(1))->method('getEntity')->willReturn($entity);
+        $model->expects($this->any())->method('getEntity')->willReturn($entity);
 
         $event = $this->getMockBuilder(EventInterface::class)->getMock();
-        $event->expects($this->exactly(2))->method('getTarget')->willReturn($model);
+        $event->expects($this->any())->method('getTarget')->willReturn($model);
 
         $this->assertNull($mock->onExecute($event));
 
@@ -97,11 +97,11 @@ class AbstractValidateTest extends TestCase
         $entity = $this->getMockBuilder(AbstractEntityWithBool::class)->getMock();
 
         $model = $this->getMockBuilder(ModelInterface::class)->getMock();
-        $model->expects($this->exactly(1))->method('getEntity')->willReturn($entity);
-        $model->expects($this->exactly(1))->method('getData')->willReturn([]);
+        $model->expects($this->any())->method('getEntity')->willReturn($entity);
+        $model->expects($this->any())->method('getData')->willReturn([]);
 
         $event = $this->getMockBuilder(EventInterface::class)->getMock();
-        $event->expects($this->exactly(2))->method('getTarget')->willReturn($model);
+        $event->expects($this->any())->method('getTarget')->willReturn($model);
 
         $this->assertNull($this->object->onExecute($event));
     }
@@ -117,14 +117,14 @@ class AbstractValidateTest extends TestCase
         $entity = $this->getMockBuilder(AbstractEntityWithBool::class)->getMock();
 
         $model = $this->getMockBuilder(ModelInterface::class)->getMock();
-        $model->expects($this->exactly(1))->method('getEntity')->willReturn($entity);
-        $model->expects($this->exactly(1))->method('getData')->willReturn($data);
+        $model->expects($this->any())->method('getEntity')->willReturn($entity);
+        $model->expects($this->any())->method('getData')->willReturn($data);
 
         $event = $this->getMockBuilder(EventInterface::class)->getMock();
-        $event->expects($this->exactly(2))->method('getTarget')->willReturn($model);
-        $event->expects($this->exactly(1))->method('getParams')->willReturn($params);
+        $event->expects($this->any())->method('getTarget')->willReturn($model);
+        $event->expects($this->any())->method('getParams')->willReturn($params);
 
-        $this->object->expects($this->once())->method('validate')->with($data, $fields);
+        $this->object->expects($this->any())->method('validate')->with($data, $fields);
         $this->assertNull($this->object->onExecute($event));
         $this->assertSame($model, $this->object->getModel());
         $this->assertSame($params, $this->object->getParams());


### PR DESCRIPTION
#### Fixes
Fixes #91

#### Changes proposed in this pull request:
- Sets all events to using a standard means of validating the model is legit.

#### Checklist
*place an x confirming all items have been verified*
- [x]  Unit tests coverage exceeds or maintains current levels (run command: ```composer test```)
- [x]  Code Sniffer has reported zero issues (run command: ```composer inspect```)
- [x]  Documentation is thorough and rich in content
