### PR TITLE
Add xml data extract for http persistence

### DIFF
--- a/tests/src/Orm/Events/Persistence/Http/DataExtract/DataExtractorFactoryTest.php
+++ b/tests/src/Orm/Events/Persistence/Http/DataExtract/DataExtractorFactoryTest.php
@@ -46,7 +46,7 @@ class DataExtractorFactoryTest extends TestCase
 
     public function testGetExtractorsWithDefaults()
     {
-        $this->assertEquals(1, count($this->object->getExtractors()));
+        $this->assertEquals(2, count($this->object->getExtractors()));
     }
 
     public function testGetExtractorsWithNoDefaults()

--- a/tests/src/Orm/Events/Persistence/Http/DataExtract/XmlTest.php
+++ b/tests/src/Orm/Events/Persistence/Http/DataExtract/XmlTest.php
@@ -1,0 +1,109 @@
+<?php
+/*
+ * The MIT License
+ *
+ * Copyright 2017 David Schoenbauer.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+namespace DSchoenbauer\Orm\Events\Persistence\Http\DataExtract;
+
+use DSchoenbauer\Tests\Orm\Events\Persistence\Http\DataExtract\TestResponseTrait;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Description of XmlTest
+ *
+ * @author David Schoenbauer
+ */
+class XmlTest extends TestCase
+{
+
+    use TestResponseTrait;
+
+    protected $object;
+
+    protected function setUp()
+    {
+        $this->object = new Xml();
+    }
+
+    /**
+     * @dataProvider matchDataProvider
+     * @param type $contentHeader
+     * @param type $result
+     */
+    public function testMatch($contentHeader, $result)
+    {
+        $this->assertEquals($result, $this->object->match($this->getResponse($contentHeader)));
+    }
+
+    public function matchDataProvider()
+    {
+        return [
+            'application/json' => ["application/json", false],
+            'application/ld+json' => ["application/ld+json", false],
+            'application/vnd.api+json' => ["application/vnd.api+json", false],
+            'application/json; charset=UTF-8' => ["application/json; charset=UTF-8", false],
+            'application/x-resource+json' => ["application/x-resource+json", false],
+            'application/x-collection+json' => ["application/x-collection+json", false],
+            'text/html' => ["text/html", false],
+            'application/xhtml+xml' => ['application/xhtml+xml', true],
+            'application/xml' => ['application/xml', true],
+            'text/xml' => ['text/xml', true],
+        ];
+    }
+
+    /**
+     * @dataProvider extractDataProvider
+     * @param type $json
+     * @param type $result
+     */
+    public function testExtract($json, $result)
+    {
+        $val = $this->object->extract($this->getResponse(null, $json));
+        $this->assertEquals($result, $val);
+    }
+
+    public function extractDataProvider()
+    {
+        return [
+            "Normal Json" => ['{"id":1}', []],
+            "Not Json" => ['{id:1}', []],
+            "Malformed Json" => ['{"key": "<div class="item">an item
+                    with newlines <span class="attrib"> and embedded
+                    </span>html</div>"}', []],
+            "Complex Data" => [
+                '{"test":{"value":{"deep":true}}}',
+                []
+            ],
+            "xml" => [
+                "<food><name>Belgian Waffles</name><price>$5.95</price>
+                <description>Two of our famous Belgian Waffles with plenty of real maple syrup</description>
+                <calories>650</calories></food>",
+                ['food' => [
+                        'name' => 'Belgian Waffles',
+                        'price' => '$5.95',
+                        'description' => 'Two of our famous Belgian Waffles with plenty of real maple syrup',
+                        'calories' => 650
+                    ]]
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
task: #95

#### Fixes
Fixes #95 

#### Changes proposed in this pull request:
- Adds a data extractor to deal with XML data 
- For use with the HTTP persistence events

#### Checklist
*place an x confirming all items have been verified*
- [x]  Unit tests coverage exceeds or maintains current levels (run command: ```composer test```)
- [x]  Code Sniffer has reported zero issues (run command: ```composer inspect```)
- [x]  Documentation is thorough and rich in content
