### PR TITLE
Depreciate HTTP presistence methods

### DIFF
--- a/src/Orm/Entity/HasUriCollection.php
+++ b/src/Orm/Entity/HasUriCollection.php
@@ -22,37 +22,20 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-namespace DSchoenbauer\Orm\Events\Persistence\Http;
-
-use DSchoenbauer\Orm\Entity\IsHttpInterface;
-use DSchoenbauer\Orm\ModelInterface;
-use Zend\Http\Request;
+namespace DSchoenbauer\Orm\Entity;
 
 /**
- * Description of Create
- * @deprecated since version 1.0.0
+ *
  * @author David Schoenbauer
  */
-class Create extends Update
+interface HasUriCollection extends IsHttpInterface
 {
 
-    protected $method = Request::METHOD_POST;
-    
-    public function runExtra(ModelInterface $model)
-    {
-            $this->crossFillId($model);
-    }
-
-    public function crossFillId(ModelInterface $model)
-    {
-        $data = $model->getData();
-        if (array_key_exists($idField = $model->getEntity()->getIdField(), $data)) {
-            $model->setId($data[$idField]);
-        }
-    }
-
-    public function getUri(IsHttpInterface $entity)
-    {
-        return $entity->getUriCollectionMask();
-    }
+    /**
+     * A collection is the source for all entities / items. New items are created by posting to and all items can be
+     * retrieved from it as a group
+     *
+     * A mask is a template that can be interpolated to add data too
+     */
+    public function getUriCollectionMask();
 }

--- a/src/Orm/Entity/HasUriEntity.php
+++ b/src/Orm/Entity/HasUriEntity.php
@@ -22,37 +22,16 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-namespace DSchoenbauer\Orm\Events\Persistence\Http;
-
-use DSchoenbauer\Orm\Entity\IsHttpInterface;
-use DSchoenbauer\Orm\ModelInterface;
-use Zend\Http\Request;
+namespace DSchoenbauer\Orm\Entity;
 
 /**
- * Description of Create
- * @deprecated since version 1.0.0
+ *
  * @author David Schoenbauer
  */
-class Create extends Update
+interface HasUriEntity extends IsHttpInterface
 {
-
-    protected $method = Request::METHOD_POST;
-    
-    public function runExtra(ModelInterface $model)
-    {
-            $this->crossFillId($model);
-    }
-
-    public function crossFillId(ModelInterface $model)
-    {
-        $data = $model->getData();
-        if (array_key_exists($idField = $model->getEntity()->getIdField(), $data)) {
-            $model->setId($data[$idField]);
-        }
-    }
-
-    public function getUri(IsHttpInterface $entity)
-    {
-        return $entity->getUriCollectionMask();
-    }
+    /**
+     * A mask is a template that can be interpolated to add data too
+     */
+    public function getUriEntityMask();
 }

--- a/src/Orm/Entity/IsHttpInterface.php
+++ b/src/Orm/Entity/IsHttpInterface.php
@@ -30,8 +30,5 @@ namespace DSchoenbauer\Orm\Entity;
  */
 interface IsHttpInterface extends EntityInterface
 {
-
-    public function getCollectionUrl();
-
-    public function getEntityUrl();
+    public function getHeaders();
 }

--- a/src/Orm/Events/AbstractEvent.php
+++ b/src/Orm/Events/AbstractEvent.php
@@ -105,7 +105,7 @@ abstract class AbstractEvent implements VisitorInterface
                 return false;
             }
         }
-        if (!is_subclass_of($model->getEntity(), $expectedEntity)) {
+        if (!is_a($model->getEntity(), $expectedEntity)) {
             if ($returnException) {
                 throw new LogicException("Entity must implement or extend $expectedEntity");
             } else {

--- a/src/Orm/Events/Framework/BackFillId.php
+++ b/src/Orm/Events/Framework/BackFillId.php
@@ -22,37 +22,36 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-namespace DSchoenbauer\Orm\Events\Persistence\Http;
+namespace DSchoenbauer\Orm\Events\Framework;
 
-use DSchoenbauer\Orm\Entity\IsHttpInterface;
+use DSchoenbauer\Orm\Entity\EntityInterface;
+use DSchoenbauer\Orm\Events\AbstractEvent;
 use DSchoenbauer\Orm\ModelInterface;
-use Zend\Http\Request;
+use Zend\EventManager\EventInterface;
 
 /**
- * Description of Create
- * @deprecated since version 1.0.0
+ * Takes Id value defined in data and populates it into the model
+ *
  * @author David Schoenbauer
  */
-class Create extends Update
+class BackFillId extends AbstractEvent
 {
 
-    protected $method = Request::METHOD_POST;
-    
-    public function runExtra(ModelInterface $model)
+    public function onExecute(EventInterface $event)
     {
-            $this->crossFillId($model);
-    }
-
-    public function crossFillId(ModelInterface $model)
-    {
-        $data = $model->getData();
-        if (array_key_exists($idField = $model->getEntity()->getIdField(), $data)) {
-            $model->setId($data[$idField]);
+        /* @var $model ModelInterface */
+        $model = $event->getTarget();
+        if (!$this->validateModel($model, EntityInterface::class)) {
+            return false;
         }
-    }
+        $data = $model->getData();
+        $idField = $model->getEntity()->getIdField();
 
-    public function getUri(IsHttpInterface $entity)
-    {
-        return $entity->getUriCollectionMask();
+        if (!array_key_exists($idField, $data)) {
+            return false;
+        }
+        $idx = $data[$idField];
+        $model->setId($idx);
+        return true;
     }
 }

--- a/src/Orm/Events/Persistence/Http/AbstractHttpEvent.php
+++ b/src/Orm/Events/Persistence/Http/AbstractHttpEvent.php
@@ -25,6 +25,8 @@
 namespace DSchoenbauer\Orm\Events\Persistence\Http;
 
 use DSchoenbauer\Orm\Entity\EntityInterface;
+use DSchoenbauer\Orm\Entity\HasUriCollection;
+use DSchoenbauer\Orm\Entity\HasUriEntity;
 use DSchoenbauer\Orm\Entity\IsHttpInterface;
 use DSchoenbauer\Orm\Enum\EventPriorities;
 use DSchoenbauer\Orm\Events\AbstractEvent;
@@ -38,7 +40,7 @@ use Zend\Http\Response;
 
 /**
  * Description of AbstractHttpEvent
- *
+ * @deprecated since version 1.0.0
  * @author David Schoenbauer
  */
 abstract class AbstractHttpEvent extends AbstractEvent
@@ -107,9 +109,17 @@ abstract class AbstractHttpEvent extends AbstractEvent
         return $this->interpolate($uri, $this->getData($model));
     }
 
+    /**
+     * Code is depreciated wired just to get it to work.
+     * @param IsHttpInterface $entity
+     * @return type
+     */
     public function getUri(IsHttpInterface $entity)
     {
-        return $entity->getEntityUrl();
+        if ($entity instanceof HasUriCollection) {
+            return $entity->getUriCollectionMask();
+        }
+        return $entity->getUriEntityMask();
     }
 
     public function getData(ModelInterface $model)

--- a/src/Orm/Events/Persistence/Http/Delete.php
+++ b/src/Orm/Events/Persistence/Http/Delete.php
@@ -29,7 +29,7 @@ use Zend\Http\Request;
 
 /**
  * Description of Delete
- *
+ * @deprecated since version 1.0.0
  * @author David Schoenbauer
  */
 class Delete extends AbstractHttpEvent

--- a/src/Orm/Events/Persistence/Http/Methods/AbstractHttpMethodEvent.php
+++ b/src/Orm/Events/Persistence/Http/Methods/AbstractHttpMethodEvent.php
@@ -1,0 +1,145 @@
+<?php
+/*
+ * The MIT License
+ *
+ * Copyright 2017 David Schoenbauer.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.    
+ */
+namespace DSchoenbauer\Orm\Events\Persistence\Http\Methods;
+
+use DSchoenbauer\Orm\Entity\IsHttpInterface;
+use DSchoenbauer\Orm\Enum\EventPriorities;
+use DSchoenbauer\Orm\Events\AbstractEvent;
+use DSchoenbauer\Orm\Events\Persistence\Http\DataExtract\DataExtractorFactory;
+use DSchoenbauer\Orm\Exception\HttpErrorException;
+use DSchoenbauer\Orm\Framework\InterpolateTrait;
+use DSchoenbauer\Orm\ModelInterface;
+use Zend\EventManager\EventInterface;
+use Zend\Http\Client;
+use Zend\Http\Response;
+
+/**
+ * Description of AbstractHttpMethodEvent
+ *
+ * @author David Schoenbauer
+ */
+abstract class AbstractHttpMethodEvent extends AbstractEvent
+{
+
+    use InterpolateTrait;
+
+    private $dataExtractorFactory;
+    private $client;
+    private $uriMask;
+    private $headers = [];
+
+    public function __construct(array $events, $uriMask, array $headers = [], $priority = EventPriorities::ON_TIME)
+    {
+        $this->setUriMask($uriMask)->setHeaders($headers);
+        parent::__construct($events, $priority);
+    }
+
+    public function onExecute(EventInterface $event)
+    {
+        $model = $event->getTarget();
+        if (!$this->validateModel($model, IsHttpInterface::class)) {
+            return;
+        }
+        $this->setHeaders($model->getEntity()->getHeaders())->applyHeaders($this->getClient());
+        return $this->send($model);
+    }
+
+    abstract public function send(ModelInterface $model);
+
+    public function getDataExtractorFactory()
+    {
+        if (!$this->dataExtractorFactory instanceof DataExtractorFactory) {
+            $this->setDataExtractorFactory(new DataExtractorFactory());
+        }
+        return $this->dataExtractorFactory;
+    }
+
+    public function setDataExtractorFactory(DataExtractorFactory $dataExtractorFactory)
+    {
+        $this->dataExtractorFactory = $dataExtractorFactory;
+        return $this;
+    }
+
+    public function getClient()
+    {
+        if (!$this->client instanceof Client) {
+            $this->setClient(new Client());
+        }
+        return $this->client;
+    }
+
+    public function setClient(Client $client)
+    {
+        $this->client = $client;
+        return $this;
+    }
+
+    public function getUriMask()
+    {
+        return $this->uriMask;
+    }
+
+    public function setUriMask($uriMask)
+    {
+        $this->uriMask = $uriMask;
+        return $this;
+    }
+
+    public function getUri($data = [])
+    {
+        return $this->interpolate($this->getUriMask(), $data);
+    }
+
+    /**
+     * Checks for errors returned in the response.
+     * @param Response $response
+     * @return Response
+     * @throws HttpErrorException
+     */
+    public function checkForError(Response $response)
+    {
+        if ($response->isSuccess()) {
+            return $response;
+        }
+        throw new HttpErrorException($response->getBody(), $response->getStatusCode());
+    }
+    
+    public function getHeaders()
+    {
+        return $this->headers;
+    }
+
+    public function setHeaders(array $headers)
+    {
+        $this->headers = $headers;
+        return $this;
+    }
+    
+    public function applyHeaders(Client $client)
+    {
+        $client->setHeaders($this->getHeaders());
+        return $this;
+    }
+}

--- a/src/Orm/Events/Persistence/Http/Methods/Delete.php
+++ b/src/Orm/Events/Persistence/Http/Methods/Delete.php
@@ -22,37 +22,26 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-namespace DSchoenbauer\Orm\Events\Persistence\Http;
+namespace DSchoenbauer\Orm\Events\Persistence\Http\Methods;
 
-use DSchoenbauer\Orm\Entity\IsHttpInterface;
 use DSchoenbauer\Orm\ModelInterface;
 use Zend\Http\Request;
 
 /**
- * Description of Create
- * @deprecated since version 1.0.0
+ * Description of Delete
+ *
  * @author David Schoenbauer
  */
-class Create extends Update
+class Delete extends AbstractHttpMethodEvent
 {
 
-    protected $method = Request::METHOD_POST;
-    
-    public function runExtra(ModelInterface $model)
+    public function send(ModelInterface $model)
     {
-            $this->crossFillId($model);
-    }
-
-    public function crossFillId(ModelInterface $model)
-    {
-        $data = $model->getData();
-        if (array_key_exists($idField = $model->getEntity()->getIdField(), $data)) {
-            $model->setId($data[$idField]);
-        }
-    }
-
-    public function getUri(IsHttpInterface $entity)
-    {
-        return $entity->getUriCollectionMask();
+        
+        $response = $this->checkForError($this->getClient()
+                ->setUri($this->getUri($model->getData()))
+                ->setMethod(Request::METHOD_DELETE)
+                ->send());
+        return $response->isSuccess();
     }
 }

--- a/src/Orm/Events/Persistence/Http/Methods/Get.php
+++ b/src/Orm/Events/Persistence/Http/Methods/Get.php
@@ -22,37 +22,22 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-namespace DSchoenbauer\Orm\Events\Persistence\Http;
+namespace DSchoenbauer\Orm\Events\Persistence\Http\Methods;
 
-use DSchoenbauer\Orm\Entity\IsHttpInterface;
 use DSchoenbauer\Orm\ModelInterface;
 use Zend\Http\Request;
 
 /**
- * Description of Create
- * @deprecated since version 1.0.0
+ * Pulls HTTP data into a model via GET method
+ *
  * @author David Schoenbauer
  */
-class Create extends Update
+class Get extends AbstractHttpMethodEvent
 {
-
-    protected $method = Request::METHOD_POST;
     
-    public function runExtra(ModelInterface $model)
+    public function send(ModelInterface $model)
     {
-            $this->crossFillId($model);
-    }
-
-    public function crossFillId(ModelInterface $model)
-    {
-        $data = $model->getData();
-        if (array_key_exists($idField = $model->getEntity()->getIdField(), $data)) {
-            $model->setId($data[$idField]);
-        }
-    }
-
-    public function getUri(IsHttpInterface $entity)
-    {
-        return $entity->getUriCollectionMask();
+        $this->getClient()->setMethod(Request::METHOD_GET)->setUri($this->getUri($model->getData()));
+        $model->setData($this->getDataExtractorFactory()->getData($this->checkForError($this->getClient()->send())));
     }
 }

--- a/src/Orm/Events/Persistence/Http/Methods/Post.php
+++ b/src/Orm/Events/Persistence/Http/Methods/Post.php
@@ -22,37 +22,31 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-namespace DSchoenbauer\Orm\Events\Persistence\Http;
+namespace DSchoenbauer\Orm\Events\Persistence\Http\Methods;
 
-use DSchoenbauer\Orm\Entity\IsHttpInterface;
 use DSchoenbauer\Orm\ModelInterface;
 use Zend\Http\Request;
 
 /**
- * Description of Create
- * @deprecated since version 1.0.0
+ * Description of Post
+ *
  * @author David Schoenbauer
  */
-class Create extends Update
+class Post extends AbstractHttpMethodEvent
 {
-
-    protected $method = Request::METHOD_POST;
     
-    public function runExtra(ModelInterface $model)
-    {
-            $this->crossFillId($model);
-    }
-
-    public function crossFillId(ModelInterface $model)
+    public function send(ModelInterface $model)
     {
         $data = $model->getData();
-        if (array_key_exists($idField = $model->getEntity()->getIdField(), $data)) {
-            $model->setId($data[$idField]);
-        }
+        $response = $this->checkForError($this->getClient()->setMethod($this->getMethod())
+                ->setParameterPost($data)
+                ->setUri($this->getUri($data))
+                ->send());
+        $model->setData($this->getDataExtractorFactory()->getData($response));
     }
-
-    public function getUri(IsHttpInterface $entity)
+    
+    public function getMethod()
     {
-        return $entity->getUriCollectionMask();
+        return Request::METHOD_POST;
     }
 }

--- a/src/Orm/Events/Persistence/Http/Methods/Put.php
+++ b/src/Orm/Events/Persistence/Http/Methods/Put.php
@@ -22,37 +22,19 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-namespace DSchoenbauer\Orm\Events\Persistence\Http;
+namespace DSchoenbauer\Orm\Events\Persistence\Http\Methods;
 
-use DSchoenbauer\Orm\Entity\IsHttpInterface;
-use DSchoenbauer\Orm\ModelInterface;
 use Zend\Http\Request;
 
 /**
- * Description of Create
- * @deprecated since version 1.0.0
+ * Description of Put
+ *
  * @author David Schoenbauer
  */
-class Create extends Update
+class Put extends Post
 {
-
-    protected $method = Request::METHOD_POST;
-    
-    public function runExtra(ModelInterface $model)
+    public function getMethod()
     {
-            $this->crossFillId($model);
-    }
-
-    public function crossFillId(ModelInterface $model)
-    {
-        $data = $model->getData();
-        if (array_key_exists($idField = $model->getEntity()->getIdField(), $data)) {
-            $model->setId($data[$idField]);
-        }
-    }
-
-    public function getUri(IsHttpInterface $entity)
-    {
-        return $entity->getUriCollectionMask();
+        return Request::METHOD_PUT;
     }
 }

--- a/src/Orm/Events/Persistence/Http/Select.php
+++ b/src/Orm/Events/Persistence/Http/Select.php
@@ -29,7 +29,7 @@ use Zend\Http\Request;
 
 /**
  * Description of Select
- *
+ * @deprecated since version 1.0.0
  * @author David Schoenbauer
  */
 class Select extends AbstractHttpEvent

--- a/src/Orm/Events/Persistence/Http/SelectAll.php
+++ b/src/Orm/Events/Persistence/Http/SelectAll.php
@@ -29,7 +29,7 @@ use Zend\Http\Request;
 
 /**
  * Description of SelectAll
- *
+ * @deprecated since version 1.0.0
  * @author David Schoenbauer
  */
 class SelectAll extends Select
@@ -38,6 +38,6 @@ class SelectAll extends Select
     
     public function getUri(IsHttpInterface $entity)
     {
-        return $entity->getCollectionUrl();
+        return $entity->getUriCollectionMask();
     }
 }

--- a/src/Orm/Events/Persistence/Http/Update.php
+++ b/src/Orm/Events/Persistence/Http/Update.php
@@ -29,7 +29,7 @@ use Zend\Http\Request;
 
 /**
  * Description of Update
- *
+ * @deprecated since version 1.0.0
  * @author David Schoenbauer
  */
 class Update extends AbstractHttpEvent

--- a/tests/src/Orm/Events/Framework/BackFillIdTest.php
+++ b/tests/src/Orm/Events/Framework/BackFillIdTest.php
@@ -1,0 +1,76 @@
+<?php
+/*
+ * The MIT License
+ *
+ * Copyright 2017 David Schoenbauer.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+namespace DSchoenbauer\Orm\Events\Framework;
+
+use DSchoenbauer\Orm\Events\AbstractEvent;
+use DSchoenbauer\Tests\Orm\Events\Persistence\Http\TestModelTrait;
+use PHPUnit\Framework\TestCase;
+use Zend\EventManager\EventInterface;
+
+/**
+ * Description of BackFillIdTest
+ *
+ * @author David Schoenbauer
+ */
+class BackFillIdTest extends TestCase
+{
+
+    use TestModelTrait;
+
+    private $object;
+
+    protected function setUp()
+    {
+        $this->object = new BackFillId();
+    }
+
+    public function testIsAnEvent()
+    {
+        $this->assertInstanceOf(AbstractEvent::class, $this->object);
+    }
+
+    public function testOnExecuteHasBadModel()
+    {
+        $event = $this->getMockBuilder(EventInterface::class)->getMock();
+        $this->assertFalse($this->object->onExecute($event));
+    }
+
+    public function testOnExecuteIdFieldIsMissing()
+    {
+        $model = $this->getModel(null, ['test' => 'notTheId'], $this->getAbstractEntity('id'));
+        $event = $this->getMockBuilder(EventInterface::class)->getMock();
+        $event->expects($this->any())->method('getTarget')->willReturn($model);
+        $this->assertFalse($this->object->onExecute($event));
+    }
+
+    public function testOnExecuteIdFieldIsPresent()
+    {
+        $model = $this->getModel(null, ['id' => 123, 'test' => 'notTheId'], $this->getAbstractEntity('id'));
+        $model->expects($this->any())->method('setId')->with('123');
+        $event = $this->getMockBuilder(EventInterface::class)->getMock();
+        $event->expects($this->any())->method('getTarget')->willReturn($model);
+        $this->assertTrue($this->object->onExecute($event));
+    }
+}

--- a/tests/src/Orm/Events/Persistence/Http/AbstractHttpEventTest.php
+++ b/tests/src/Orm/Events/Persistence/Http/AbstractHttpEventTest.php
@@ -24,7 +24,7 @@
  */
 namespace DSchoenbauer\Orm\Events\Persistence\Http;
 
-use DSchoenbauer\Orm\Entity\IsHttpInterface;
+use DSchoenbauer\Orm\Entity\HasUriEntity;
 use DSchoenbauer\Orm\Events\Persistence\Http\DataExtract\DataExtractorFactory;
 use DSchoenbauer\Orm\Events\Persistence\Http\DataExtract\DataExtractorInterface;
 use DSchoenbauer\Orm\Exception\HttpErrorException;
@@ -34,11 +34,10 @@ use PHPUnit\Framework\TestCase;
 use stdClass;
 use Zend\EventManager\EventInterface;
 use Zend\Http\Client;
-use Zend\Http\Response;
 
 /**
  * Description of AbstractHttpEventTest
- *
+ * @deprecated since version 1.0.0
  * @author David Schoenbauer
  */
 class AbstractHttpEventTest extends TestCase
@@ -93,15 +92,15 @@ use TestModelTrait;
 
     public function testGetUri()
     {
-        $entity = $this->getMockBuilder(IsHttpInterface::class)->getMock();
-        $entity->expects($this->any())->method('getEntityUrl')->willReturn('test');
+        $entity = $this->getMockBuilder(HasUriEntity::class)->getMock();
+        $entity->expects($this->any())->method('getUriEntityMask')->willReturn('test');
 
         $this->assertEquals('test', $this->object->getUri($entity));
     }
 
     public function testBuildUri()
     {
-        $this->object->buildUri($this->getModel(1, ['id' => 1], $this->getIsHttp('id', 'http://test.com')));
+        $this->object->buildUri($this->getModel(1, ['id' => 1], $this->getIsHttp('id', 'http://test.com', true)));
     }
 
     public function testBuildUriBadEntity()

--- a/tests/src/Orm/Events/Persistence/Http/DataExtract/TestResponseTrait.php
+++ b/tests/src/Orm/Events/Persistence/Http/DataExtract/TestResponseTrait.php
@@ -28,7 +28,6 @@ use Zend\Http\Header\HeaderInterface;
 use Zend\Http\Headers;
 use Zend\Http\Response;
 
-
 /**
  * Description of TestResponseTrait
  *
@@ -58,10 +57,14 @@ trait TestResponseTrait
         $responseMock->expects($this->any())
             ->method('getBody')
             ->willReturn($body);
-        
+
         $responseMock->expects($this->any())
             ->method('getStatusCode')
             ->willReturn($statusCode);
+
+        $responseMock->expects($this->any())
+            ->method('isSuccess')
+            ->willReturn(in_array($statusCode, range(200, 299)));
 
         return $responseMock;
     }

--- a/tests/src/Orm/Events/Persistence/Http/Methods/AbstractHttpMethodEventTest.php
+++ b/tests/src/Orm/Events/Persistence/Http/Methods/AbstractHttpMethodEventTest.php
@@ -1,0 +1,159 @@
+<?php
+/*
+ * The MIT License
+ *
+ * Copyright 2017 David Schoenbauer.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+namespace DSchoenbauer\Orm\Events\Persistence\Http\Methods;
+
+use DSchoenbauer\Orm\Entity\IsHttpInterface;
+use DSchoenbauer\Orm\Events\AbstractEvent;
+use DSchoenbauer\Orm\Events\Persistence\Http\DataExtract\DataExtractorFactory;
+use DSchoenbauer\Orm\Exception\HttpErrorException;
+use DSchoenbauer\Tests\Orm\Events\Persistence\Http\DataExtract\TestResponseTrait;
+use DSchoenbauer\Tests\Orm\Events\Persistence\Http\TestModelTrait;
+use PHPUnit\Framework\TestCase;
+use Zend\EventManager\EventInterface;
+use Zend\Http\Client;
+
+/**
+ * Description of AbstractHttpMethodTest
+ *
+ * @author David Schoenbauer
+ */
+class AbstractHttpMethodEventTest extends TestCase
+{
+
+    use TestModelTrait;
+    use TestResponseTrait;
+    /**
+     *
+     * @var  AbstractHttpMethodEvent $object
+     */
+    private $object;
+
+    protected function setUp()
+    {
+        $this->object = $this->getMockForAbstractClass(AbstractHttpMethodEvent::class,[[],'']);
+    }
+
+    public function testOnExecuteNoGood(){
+        $event = $this->getMockBuilder(EventInterface::class)->getMock();
+        $this->object->expects($this->exactly(0))->method('send');
+        $this->assertNull($this->object->onExecute($event));
+    }
+    
+    public function testOnExecuteGood(){
+        $entity = $this->getMockBuilder(IsHttpInterface::class)->getMock();
+        $entity->expects($this->any())->method('getHeaders')->willReturn([]);
+        $model = $this->getModel(0,[],$entity);
+        
+        $event = $this->getMockBuilder(EventInterface::class)->getMock();
+        $event->expects($this->any())->method('getTarget')->willReturn($model);
+        
+        $this->object->expects($this->exactly(1))->method('send')->with($model);
+        $this->assertNull($this->object->onExecute($event));
+    }
+
+
+    public function testIsEvent()
+    {
+        $this->assertInstanceOf(AbstractEvent::class, $this->object);
+    }
+
+    public function testClientLazyLoad()
+    {
+        $this->assertInstanceOf(Client::class, $this->object->getClient());
+    }
+    
+    public function testClientLoad()
+    {
+        $clientMock = $this->getMockBuilder(Client::class)->getMock();
+        $this->assertSame($clientMock, $this->object->setClient($clientMock)->getClient());
+    }
+
+    public function testDataExtractorFactoryLazyLoad()
+    {
+        $this->assertInstanceOf(DataExtractorFactory::class, $this->object->getDataExtractorFactory());
+    }
+
+    public function testUriMask()
+    {
+        $this->assertEquals('test', $this->object->setUriMask('test')->getUriMask());
+        $this->assertEquals('test-again', $this->object->setUriMask('test-again')->getUriMask());
+    }
+
+    public function testGetUriNoParameter()
+    {
+        $this->assertEquals('test', $this->object->setUriMask('test')->getUri());
+    }
+
+    /**
+     * @dataProvider getUriDataProvider
+     * @param string $result
+     * @param string $mask
+     * @param array $data
+     */
+    public function testGetUri($result, $mask, array $data)
+    {
+        $this->assertEquals($result, $this->object->setUriMask($mask)->getUri($data));
+    }
+
+    public function getUriDataProvider()
+    {
+        return [
+            'Null Test' => [null, null, []],
+            'Too much data' => ['cat/1', 'cat/{id}', ['id' => 1, 'project-id' => 2]],
+            'Too little data' => ['cat/{id}', 'cat/{id}', ['project-id' => 2]],
+            '1 parameter' => ['category/123', 'category/{id}', ['id' => 123]],
+            '2 parameter' => ['project/2/cat/1', 'project/{project-id}/cat/{id}', ['id' => 1, 'project-id' => 2]],
+            'repeated parameter' => ['4/4/4','{project-id}/{project-id}/{project-id}',  ['project-id' => 4]],
+        ];
+    }
+    
+    
+    public function testCheckForErrorIsError()
+    {
+        $response = $this->getResponse("someHeader");
+        $this->assertSame($response, $this->object->checkForError($response));
+    }
+
+    public function testCheckForErrorNoError()
+    {
+        $this->expectException(HttpErrorException::class);
+        $this->expectExceptionCode(500);
+        $this->expectExceptionMessage("some body");
+        $this->assertTrue($this->object->checkForError($this->getResponse("","some body", 500)));
+    }
+
+    public function testHeaders(){
+        $data = ['test'=>'value'];
+        $this->assertEquals([],$this->object->getHeaders());
+        $this->assertEquals($data,$this->object->setHeaders($data)->getHeaders());
+    }
+    
+    public function testApplyHeaders(){
+        $data = ['test'=>'value'];
+        $client = $this->getMockBuilder(Client::class)->getMock();
+        $client->expects($this->any())->method('setHeaders')->with($data);
+        $client = $this->object->setHeaders($data)->applyHeaders($client);
+    }
+}

--- a/tests/src/Orm/Events/Persistence/Http/Methods/DeleteTest.php
+++ b/tests/src/Orm/Events/Persistence/Http/Methods/DeleteTest.php
@@ -22,7 +22,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-namespace DSchoenbauer\Orm\Events\Persistence\Http;
+namespace DSchoenbauer\Orm\Events\Persistence\Http\Methods;
 
 use DSchoenbauer\Orm\Exception\HttpErrorException;
 use DSchoenbauer\Orm\Framework\AttributeCollection;
@@ -47,29 +47,22 @@ class DeleteTest extends TestCase
 
     protected function setUp()
     {
-        $this->object = new Delete();
-    }
-
-    public function testGetMethod()
-    {
-        $this->assertEquals(Request::METHOD_DELETE, $this->object->getMethod());
+        $this->object = new Delete([],'');
     }
 
     public function testRun()
     {
         $response = $this->getResponse("");
-        $attributes = $this->getMockBuilder(AttributeCollection::class)->getMock();
-        $attributes->expects($this->once())->method('set')->with('response', $response);
 
-        $model = $this->getModel(1998, [], $this->getIsHttp(null, 'bobsYouUncle', 'bobsYourAunt', true));
-        $model->expects($this->once())->method('getAttributes')->willReturn($attributes);
+
+        $model = $this->getModel(1998, [], $this->getIsHttp(null, 'bobsYouUncle', 'bobsYourAunt'));
 
         $client = $this->getMockBuilder(Client::class)->getMock();
         $client->expects($this->once())->method('setUri')->with('bobsYouUncle')->willReturnSelf();
         $client->expects($this->once())->method('setMethod')->with(Request::METHOD_DELETE)->willReturnSelf();
         $client->expects($this->once())->method('send')->willReturn($response);
 
-        $this->object->setClient($client)->run($model);
+        $this->object->setUriMask('bobsYouUncle')->setClient($client)->send($model);
     }
 
     public function testRunFail()
@@ -79,13 +72,13 @@ class DeleteTest extends TestCase
         $this->expectExceptionMessage("Test");
         $response = $this->getResponse("", "Test", 500);
 
-        $model = $this->getModel(1998, [], $this->getIsHttp(null, 'bobsYouUncle', 'bobsYourAunt', true));
+        $model = $this->getModel(1998, [], $this->getIsHttp(null, 'bobsYouUncle', 'bobsYourAunt'));
 
         $client = $this->getMockBuilder(Client::class)->getMock();
         $client->expects($this->once())->method('setUri')->with('bobsYouUncle')->willReturnSelf();
         $client->expects($this->once())->method('setMethod')->with(Request::METHOD_DELETE)->willReturnSelf();
         $client->expects($this->once())->method('send')->willReturn($response);
 
-        $this->object->setClient($client)->run($model);
+        $this->object->setUriMask('bobsYouUncle')->setClient($client)->send($model);
     }
 }

--- a/tests/src/Orm/Events/Persistence/Http/Methods/GetTest.php
+++ b/tests/src/Orm/Events/Persistence/Http/Methods/GetTest.php
@@ -22,70 +22,64 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-namespace DSchoenbauer\Orm\Events\Persistence\Http;
+namespace DSchoenbauer\Orm\Events\Persistence\Http\Methods;
 
 use DSchoenbauer\Orm\Exception\HttpErrorException;
-use DSchoenbauer\Orm\Framework\AttributeCollection;
 use DSchoenbauer\Tests\Orm\Events\Persistence\Http\DataExtract\TestResponseTrait;
 use DSchoenbauer\Tests\Orm\Events\Persistence\Http\TestModelTrait;
 use PHPUnit\Framework\TestCase;
 use Zend\Http\Client;
 use Zend\Http\Request;
 
+
 /**
- * Description of DeleteTest
+ * Description of GetTest
  *
  * @author David Schoenbauer
  */
-class DeleteTest extends TestCase
+class GetTest extends TestCase
 {
+    
+    /**
+     * @var Get
+     */
+    private $object;
 
-    protected $object;
-
-    use TestResponseTrait;
     use TestModelTrait;
-
+    use TestResponseTrait;
+    
     protected function setUp()
     {
-        $this->object = new Delete();
+        $this->object = new Get([],'');
     }
-
-    public function testGetMethod()
+        public function testRun()
     {
-        $this->assertEquals(Request::METHOD_DELETE, $this->object->getMethod());
-    }
-
-    public function testRun()
-    {
-        $response = $this->getResponse("");
-        $attributes = $this->getMockBuilder(AttributeCollection::class)->getMock();
-        $attributes->expects($this->once())->method('set')->with('response', $response);
-
-        $model = $this->getModel(1998, [], $this->getIsHttp(null, 'bobsYouUncle', 'bobsYourAunt', true));
-        $model->expects($this->once())->method('getAttributes')->willReturn($attributes);
+        $data = ['test' => 1, 'id' => 1999];
+        $model = $this->getModel(1999, $data, $this->getIsHttp('id', 'entity', 'collection'));
+        $model->expects($this->once())->method('setData')->with($data);
 
         $client = $this->getMockBuilder(Client::class)->getMock();
-        $client->expects($this->once())->method('setUri')->with('bobsYouUncle')->willReturnSelf();
-        $client->expects($this->once())->method('setMethod')->with(Request::METHOD_DELETE)->willReturnSelf();
-        $client->expects($this->once())->method('send')->willReturn($response);
+        $client->expects($this->any())->method('setMethod')->with(Request::METHOD_GET)->willReturnSelf();
+        $client->expects($this->any())->method('setUri')->with('entity')->willReturnSelf();
+        $client->expects($this->any())->method('send')->willReturn($this->getResponse('somethingJson', json_encode($data)));
 
-        $this->object->setClient($client)->run($model);
+        $this->object->setUriMask('entity')->setClient($client)->send($model);
     }
 
     public function testRunFail()
     {
         $this->expectException(HttpErrorException::class);
         $this->expectExceptionCode(500);
-        $this->expectExceptionMessage("Test");
-        $response = $this->getResponse("", "Test", 500);
-
-        $model = $this->getModel(1998, [], $this->getIsHttp(null, 'bobsYouUncle', 'bobsYourAunt', true));
+        $this->expectExceptionMessage('{"test":1,"id":1999}');
+        
+        $data = ['test' => 1, 'id' => 1999];
+        $model = $this->getModel(1999, $data, $this->getIsHttp('id', 'entity', 'collection'));
 
         $client = $this->getMockBuilder(Client::class)->getMock();
-        $client->expects($this->once())->method('setUri')->with('bobsYouUncle')->willReturnSelf();
-        $client->expects($this->once())->method('setMethod')->with(Request::METHOD_DELETE)->willReturnSelf();
-        $client->expects($this->once())->method('send')->willReturn($response);
+        $client->expects($this->any())->method('setMethod')->with(Request::METHOD_GET)->willReturnSelf();
+        $client->expects($this->any())->method('setUri')->with('entity')->willReturnSelf();
+        $client->expects($this->any())->method('send')->willReturn($this->getResponse('somethingJson', json_encode($data), 500));
 
-        $this->object->setClient($client)->run($model);
+        $this->object->setUriMask('entity')->setClient($client)->send($model);
     }
 }

--- a/tests/src/Orm/Events/Persistence/Http/Methods/PostTest.php
+++ b/tests/src/Orm/Events/Persistence/Http/Methods/PostTest.php
@@ -22,10 +22,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-namespace DSchoenbauer\Orm\Events\Persistence\Http;
+namespace DSchoenbauer\Orm\Events\Persistence\Http\Methods;
 
 use DSchoenbauer\Orm\Exception\HttpErrorException;
-use DSchoenbauer\Orm\Framework\AttributeCollection;
 use DSchoenbauer\Tests\Orm\Events\Persistence\Http\DataExtract\TestResponseTrait;
 use DSchoenbauer\Tests\Orm\Events\Persistence\Http\TestModelTrait;
 use PHPUnit\Framework\TestCase;
@@ -33,59 +32,62 @@ use Zend\Http\Client;
 use Zend\Http\Request;
 
 /**
- * Description of DeleteTest
+ * Description of PostTest
  *
  * @author David Schoenbauer
  */
-class DeleteTest extends TestCase
+class PostTest extends TestCase
 {
 
     protected $object;
 
-    use TestResponseTrait;
     use TestModelTrait;
+    use TestResponseTrait;
 
     protected function setUp()
     {
-        $this->object = new Delete();
+        $this->object = new Post([],'');
     }
 
     public function testGetMethod()
     {
-        $this->assertEquals(Request::METHOD_DELETE, $this->object->getMethod());
+        $this->assertEquals(Request::METHOD_POST, $this->object->getMethod());
     }
-
-    public function testRun()
+    
+    public function testSend()
     {
-        $response = $this->getResponse("");
-        $attributes = $this->getMockBuilder(AttributeCollection::class)->getMock();
-        $attributes->expects($this->once())->method('set')->with('response', $response);
+        $data = ['id' => 1999, 'test' => 100];
 
-        $model = $this->getModel(1998, [], $this->getIsHttp(null, 'bobsYouUncle', 'bobsYourAunt', true));
-        $model->expects($this->once())->method('getAttributes')->willReturn($attributes);
+        $response = $this->getResponse('something/json', \json_encode($data));
 
         $client = $this->getMockBuilder(Client::class)->getMock();
-        $client->expects($this->once())->method('setUri')->with('bobsYouUncle')->willReturnSelf();
-        $client->expects($this->once())->method('setMethod')->with(Request::METHOD_DELETE)->willReturnSelf();
+        $client->expects($this->once())->method('setUri')->with('bobsYourUncle')->willReturnSelf();
+        $client->expects($this->once())->method('setParameterPost')->with($data)->willReturnSelf();
+        $client->expects($this->once())->method('setMethod')->with(Request::METHOD_POST)->willReturnSelf();
         $client->expects($this->once())->method('send')->willReturn($response);
 
-        $this->object->setClient($client)->run($model);
+        $model = $this->getModel(0, $data, $this->getIsHttp('id', 'bobsYourAunt', 'bobsYourUncle'));
+
+        $this->object->setUriMask('bobsYourUncle')->setClient($client)->send($model);
     }
 
-    public function testRunFail()
+    public function testSendFail()
     {
+        $data = ['id' => 1999, 'test' => 100];
+
         $this->expectException(HttpErrorException::class);
         $this->expectExceptionCode(500);
-        $this->expectExceptionMessage("Test");
-        $response = $this->getResponse("", "Test", 500);
-
-        $model = $this->getModel(1998, [], $this->getIsHttp(null, 'bobsYouUncle', 'bobsYourAunt', true));
+        $this->expectExceptionMessage(\json_encode($data));
+        $response = $this->getResponse('something/json', \json_encode($data), 500);
 
         $client = $this->getMockBuilder(Client::class)->getMock();
-        $client->expects($this->once())->method('setUri')->with('bobsYouUncle')->willReturnSelf();
-        $client->expects($this->once())->method('setMethod')->with(Request::METHOD_DELETE)->willReturnSelf();
+        $client->expects($this->once())->method('setUri')->with('bobsYourUncle')->willReturnSelf();
+        $client->expects($this->once())->method('setParameterPost')->with($data)->willReturnSelf();
+        $client->expects($this->once())->method('setMethod')->with(Request::METHOD_POST)->willReturnSelf();
         $client->expects($this->once())->method('send')->willReturn($response);
 
-        $this->object->setClient($client)->run($model);
+        $model = $this->getModel(0, $data, $this->getIsHttp('id', 'bobsYourAunt', 'bobsYourUncle'));
+
+        $this->object->setUriMask('bobsYourUncle')->setClient($client)->send($model);
     }
 }

--- a/tests/src/Orm/Events/Persistence/Http/Methods/PutTest.php
+++ b/tests/src/Orm/Events/Persistence/Http/Methods/PutTest.php
@@ -22,10 +22,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-namespace DSchoenbauer\Orm\Events\Persistence\Http;
+namespace DSchoenbauer\Orm\Events\Persistence\Http\Methods;
 
 use DSchoenbauer\Orm\Exception\HttpErrorException;
-use DSchoenbauer\Orm\Framework\AttributeCollection;
 use DSchoenbauer\Tests\Orm\Events\Persistence\Http\DataExtract\TestResponseTrait;
 use DSchoenbauer\Tests\Orm\Events\Persistence\Http\TestModelTrait;
 use PHPUnit\Framework\TestCase;
@@ -33,59 +32,69 @@ use Zend\Http\Client;
 use Zend\Http\Request;
 
 /**
- * Description of DeleteTest
+ * Description of PutTest
  *
  * @author David Schoenbauer
  */
-class DeleteTest extends TestCase
+class PutTest extends TestCase
 {
 
-    protected $object;
-
-    use TestResponseTrait;
     use TestModelTrait;
+    use TestResponseTrait;
+
+    /**
+     *
+     * @var Put
+     */
+    protected $object;
 
     protected function setUp()
     {
-        $this->object = new Delete();
+        $this->object = new Put([], '');
     }
 
     public function testGetMethod()
     {
-        $this->assertEquals(Request::METHOD_DELETE, $this->object->getMethod());
+        $this->assertEquals(Request::METHOD_PUT, $this->object->getMethod());
     }
 
     public function testRun()
     {
-        $response = $this->getResponse("");
-        $attributes = $this->getMockBuilder(AttributeCollection::class)->getMock();
-        $attributes->expects($this->once())->method('set')->with('response', $response);
+        $data = ['id' => 1999, 'test' => 100];
 
-        $model = $this->getModel(1998, [], $this->getIsHttp(null, 'bobsYouUncle', 'bobsYourAunt', true));
-        $model->expects($this->once())->method('getAttributes')->willReturn($attributes);
+        $response = $this->getResponse('something/json', \json_encode($data));
 
         $client = $this->getMockBuilder(Client::class)->getMock();
-        $client->expects($this->once())->method('setUri')->with('bobsYouUncle')->willReturnSelf();
-        $client->expects($this->once())->method('setMethod')->with(Request::METHOD_DELETE)->willReturnSelf();
+        $client->expects($this->once())->method('setUri')->with('bobsYourAunt')->willReturnSelf();
+        $client->expects($this->once())->method('setParameterPost')->with($data)->willReturnSelf();
+        $client->expects($this->once())->method('setMethod')->with(Request::METHOD_PUT)->willReturnSelf();
         $client->expects($this->once())->method('send')->willReturn($response);
 
-        $this->object->setClient($client)->run($model);
+        $model = $this->getModel(0, $data, $this->getIsHttp('id', 'bobsYourAunt', 'bobsYourUncle'));
+        $model->expects($this->once())->method('setData')->with($data);
+
+        $this->object->setUriMask('bobsYourAunt')->setClient($client)->send($model);
     }
 
     public function testRunFail()
     {
+        $data = ['id' => 1999, 'test' => 100];
+
         $this->expectException(HttpErrorException::class);
         $this->expectExceptionCode(500);
-        $this->expectExceptionMessage("Test");
-        $response = $this->getResponse("", "Test", 500);
+        $this->expectExceptionMessage(\json_encode($data));
 
-        $model = $this->getModel(1998, [], $this->getIsHttp(null, 'bobsYouUncle', 'bobsYourAunt', true));
+        $response = $this->getResponse('something/json', \json_encode($data), 500);
 
         $client = $this->getMockBuilder(Client::class)->getMock();
-        $client->expects($this->once())->method('setUri')->with('bobsYouUncle')->willReturnSelf();
-        $client->expects($this->once())->method('setMethod')->with(Request::METHOD_DELETE)->willReturnSelf();
+        $client->expects($this->once())->method('setUri')->with('bobsYourAunt')->willReturnSelf();
+        $client->expects($this->once())->method('setParameterPost')->with($data)->willReturnSelf();
+        $client->expects($this->once())->method('setMethod')->with(Request::METHOD_PUT)->willReturnSelf();
         $client->expects($this->once())->method('send')->willReturn($response);
 
-        $this->object->setClient($client)->run($model);
+        $model = $this->getModel(0, $data, $this->getIsHttp('id', 'bobsYourAunt', 'bobsYourUncle'));
+        $model->expects($this->exactly(0))->method('setData');
+
+        $this->object->setUriMask('bobsYourAunt')->setClient($client)->send($model);
     }
 }

--- a/tests/src/Orm/Events/Persistence/Http/SelectTest.php
+++ b/tests/src/Orm/Events/Persistence/Http/SelectTest.php
@@ -56,7 +56,7 @@ class SelectTest extends TestCase
     public function testRun()
     {
         $data = ['test' => 1, 'id' => 1999];
-        $model = $this->getModel(1999, $data, $this->getIsHttp('id', 'entity', 'collection'));
+        $model = $this->getModel(1999, $data, $this->getIsHttp('id', 'entity', 'collection', true));
         $model->expects($this->once())->method('setData')->with($data);
 
         $client = $this->getMockBuilder(Client::class)->getMock();
@@ -72,9 +72,9 @@ class SelectTest extends TestCase
         $this->expectException(\DSchoenbauer\Orm\Exception\HttpErrorException::class);
         $this->expectExceptionCode(500);
         $this->expectExceptionMessage('{"test":1,"id":1999}');
-        
+
         $data = ['test' => 1, 'id' => 1999];
-        $model = $this->getModel(1999, $data, $this->getIsHttp('id', 'entity', 'collection'));
+        $model = $this->getModel(1999, $data, $this->getIsHttp('id', 'entity', 'collection', true));
 
         $client = $this->getMockBuilder(Client::class)->getMock();
         $client->expects($this->once())->method('setMethod')->with(Request::METHOD_GET)->willReturnSelf();

--- a/tests/src/Orm/Events/Persistence/Http/TestModelTrait.php
+++ b/tests/src/Orm/Events/Persistence/Http/TestModelTrait.php
@@ -25,8 +25,10 @@
 namespace DSchoenbauer\Tests\Orm\Events\Persistence\Http;
 
 use DSchoenbauer\Orm\Entity\EntityInterface;
-use DSchoenbauer\Orm\Entity\IsHttpInterface;
+use DSchoenbauer\Orm\Entity\HasUriCollection;
+use DSchoenbauer\Orm\Entity\HasUriEntity;
 use DSchoenbauer\Orm\ModelInterface;
+use PHPUnit_Framework_MockObject_MockObject;
 
 /**
  * Description of TestModelTrait
@@ -41,7 +43,7 @@ trait TestModelTrait
      * @param type $idValue
      * @param type $data
      * @param type $entity
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return PHPUnit_Framework_MockObject_MockObject
      */
     public function getModel($idValue = 0, $data = [], $entity = null)
     {
@@ -67,12 +69,16 @@ trait TestModelTrait
         return $entity;
     }
 
-    public function getIsHttp($idField = null, $entityUrl = null, $collectionUrl = null)
+    public function getIsHttp($idField = null, $entityUrl = null, $collectionUrl = null, $useEntity = false)
     {
-        $entity = $this->getMockBuilder(IsHttpInterface::class)->getMock();
+
+        $entity = $this->getMockBuilder(($useEntity ? HasUriEntity::class : HasUriCollection::class))->getMock();
         $entity->expects($this->any())->method('getIdField')->willReturn($idField);
-        $entity->expects($this->any())->method('getEntityUrl')->willReturn($entityUrl);
-        $entity->expects($this->any())->method('getCollectionUrl')->willReturn($collectionUrl);
+        if ($useEntity) {
+            $entity->expects($this->any())->method('getUriEntityMask')->willReturn($entityUrl);
+        } else {
+            $entity->expects($this->any())->method('getUriCollectionMask')->willReturn($collectionUrl);
+        }
         return $entity;
     }
 }

--- a/tests/src/Orm/Events/Persistence/Http/UpdateTest.php
+++ b/tests/src/Orm/Events/Persistence/Http/UpdateTest.php
@@ -66,7 +66,7 @@ class UpdateTest extends TestCase
         $client->expects($this->once())->method('setMethod')->with(Request::METHOD_PUT)->willReturnSelf();
         $client->expects($this->once())->method('send')->willReturn($response);
 
-        $model = $this->getModel(0, $data, $this->getIsHttp('id', 'bobsYourAunt', 'bobsYourUncle'));
+        $model = $this->getModel(0, $data, $this->getIsHttp('id', 'bobsYourAunt', 'bobsYourUncle', true));
         $model->expects($this->once())->method('setData')->with($data);
 
         $this->object->setClient($client)->run($model);
@@ -75,7 +75,7 @@ class UpdateTest extends TestCase
     public function testRunFail()
     {
         $data = ['id' => 1999, 'test' => 100];
-        
+
         $this->expectException(HttpErrorException::class);
         $this->expectExceptionCode(500);
         $this->expectExceptionMessage(\json_encode($data));
@@ -88,7 +88,7 @@ class UpdateTest extends TestCase
         $client->expects($this->once())->method('setMethod')->with(Request::METHOD_PUT)->willReturnSelf();
         $client->expects($this->once())->method('send')->willReturn($response);
 
-        $model = $this->getModel(0, $data, $this->getIsHttp('id', 'bobsYourAunt', 'bobsYourUncle'));
+        $model = $this->getModel(0, $data, $this->getIsHttp('id', 'bobsYourAunt', 'bobsYourUncle', true));
         $model->expects($this->exactly(0))->method('setData');
 
         $this->object->setClient($client)->run($model);


### PR DESCRIPTION
Old HTTP methods were depreciated as they did too much. They processed HTTP
in a very narrow scope and if they needed to operate in a different
manner they couldn't. Four new methods were added to replace the
original.

task: #97

#### Fixes
Fixes #97 

#### Changes proposed in this pull request:
- Depreciate old HTTP Persistence methods
- Implement new HTTP commands

#### Checklist
*place an x confirming all items have been verified*
- [x]  Unit tests coverage exceeds or maintains current levels (run command: ```composer test```)
- [x]  Code Sniffer has reported zero issues (run command: ```composer inspect```)
- [x]  Documentation is thorough and rich in content
