### PR TITLE
Bug/109 approved fields only pdo

### DIFF
--- a/src/Orm/Events/Persistence/Pdo/AbstractPdoEvent.php
+++ b/src/Orm/Events/Persistence/Pdo/AbstractPdoEvent.php
@@ -62,6 +62,20 @@ abstract class AbstractPdoEvent extends AbstractEvent
         return $this->commit($event);
     }
 
+    public function reduceFields(array $data = [], array $fields = [])
+    {
+        $reduced = array_intersect_key($data, array_flip($fields));
+
+        return array_filter($reduced, function ($value) {
+            if (is_scalar($value)) {
+                return true;
+            } elseif (is_object($value) && method_exists($value, '__toString')) {
+                return true;
+            }
+            return false;
+        });
+    }
+
     abstract protected function commit(EventInterface $event);
 
     /**

--- a/src/Orm/Events/Persistence/Pdo/AbstractPdoEvent.php
+++ b/src/Orm/Events/Persistence/Pdo/AbstractPdoEvent.php
@@ -67,9 +67,7 @@ abstract class AbstractPdoEvent extends AbstractEvent
         $reduced = array_intersect_key($data, array_flip($fields));
 
         return array_filter($reduced, function ($value) {
-            if (is_scalar($value)) {
-                return true;
-            } elseif (is_object($value) && method_exists($value, '__toString')) {
+            if (is_scalar($value) || (is_object($value) && method_exists($value, '__toString'))) {
                 return true;
             }
             return false;

--- a/src/Orm/Events/Persistence/Pdo/Create.php
+++ b/src/Orm/Events/Persistence/Pdo/Create.php
@@ -38,7 +38,7 @@ class Create extends AbstractPdoEvent
             $idx = $this->getCreate()
                 ->setIsStrict()
                 ->setTable($entity->getTable())
-                ->setData($model->getData())
+                ->setData($this->reduceFields($model->getData(), $entity->getAllFields()))
                 ->execute($this->getAdapter());
             $model->setId($idx);
         } catch (NoRecordsAffectedException $exc) {

--- a/src/Orm/Events/Persistence/Pdo/Update.php
+++ b/src/Orm/Events/Persistence/Pdo/Update.php
@@ -6,7 +6,6 @@
  */
 namespace DSchoenbauer\Orm\Events\Persistence\Pdo;
 
-use DSchoenbauer\Orm\Entity\EntityInterface;
 use DSchoenbauer\Orm\Exception\RecordNotFoundException;
 use DSchoenbauer\Orm\ModelInterface;
 use DSchoenbauer\Sql\Command\Update as UpdateCommand;
@@ -38,7 +37,8 @@ class Update extends AbstractPdoEvent
             $entity = $model->getEntity();
             $this->getUpdate()
                 ->setIsStrict()
-                ->setTable($entity->getTable())->setData($model->getData())
+                ->setTable($entity->getTable())
+                ->setData($this->reduceFields($model->getData(), $entity->getAllFields()))
                 ->setWhere(new ArrayWhere([$entity->getIdField() => $model->getId()]))
                 ->execute($this->getAdapter());
         } catch (NoRecordsAffectedException $exc) {

--- a/tests/src/Orm/Events/Persistence/Pdo/AbstractPdoEventTest.php
+++ b/tests/src/Orm/Events/Persistence/Pdo/AbstractPdoEventTest.php
@@ -1,0 +1,93 @@
+<?php
+/*
+ * The MIT License
+ *
+ * Copyright 2017 David Schoenbauer.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+namespace DSchoenbauer\Orm\Events\Persistence\Pdo;
+
+use DSchoenbauer\Orm\Entity\EntityInterface;
+use DSchoenbauer\Orm\ModelInterface;
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Zend\EventManager\EventInterface;
+
+/**
+ * Description of AbstractPdoEventTest
+ *
+ * @author David Schoenbauer
+ */
+class AbstractPdoEventTest extends TestCase
+{
+
+    /**
+     *
+     * @var AbstractPdoEvent
+     */
+    private $object;
+
+    protected function setUp()
+    {
+        $this->object = $this->getMockForAbstractClass(AbstractPdoEvent::class, [], '', false);
+    }
+
+    public function testAdapter()
+    {
+        $adapter = $this->getMockBuilder(PDO::class)->disableOriginalConstructor()->getMock();
+        $this->assertSame($adapter, $this->object->setAdapter($adapter)->getAdapter());
+    }
+
+    public function testConstruct()
+    {
+
+        $events = ['test', 'test2'];
+        $adapter = $this->getMockBuilder(PDO::class)->disableOriginalConstructor()->getMock();
+        $priority = "HIGH";
+        $this->object = $this->getMockForAbstractClass(AbstractPdoEvent::class, [$events, $adapter, $priority], '', true);
+        $this->assertSame($adapter, $this->object->getAdapter());
+        $this->assertEquals($events, $this->object->getEvents());
+        $this->assertEquals($priority, $this->object->getPriority());
+    }
+    
+    public function testOnExecuteBadTarget(){
+        $event = $this->getMockBuilder(EventInterface::class)->getMock();
+        $this->assertNull($this->object->onExecute($event));
+    }
+    
+    public function testOnExecuteGoodTargetBadInterface(){
+        $model = $this->getMockBuilder(ModelInterface::class)->getMock();
+        $event = $this->getMockBuilder(EventInterface::class)->getMock();
+        $event->expects($this->any())->method('getTarget')->willReturn($model);
+        $this->assertNull($this->object->onExecute($event));
+    }
+    
+    public function testOnExecuteGood(){
+        $entity = $this->getMockBuilder(EntityInterface::class)->getMock();
+        $model = $this->getMockBuilder(ModelInterface::class)->getMock();
+        $model->expects($this->any())->method('getEntity')->willReturn($entity);
+        
+        $event = $this->getMockBuilder(EventInterface::class)->getMock();
+        $event->expects($this->any())->method('getTarget')->willReturn($model);
+
+        $this->object->expects($this->once())->method('commit')->with($event);
+        $this->object->onExecute($event);
+    }
+}

--- a/tests/src/Orm/Events/Persistence/Pdo/CreateTest.php
+++ b/tests/src/Orm/Events/Persistence/Pdo/CreateTest.php
@@ -68,9 +68,11 @@ class CreateTest extends TestCase
         $table = "someTable";
         $idField = "id";
         $data = ['test' => 1, 'some_id' => 2];
+        $fields = ['test', 'some_id'];
 
         $entity = $this->getMockBuilder(EntityInterface::class)->getMock();
         $entity->expects($this->any())->method('getTable')->willReturn($table);
+        $entity->expects($this->any())->method('getAllFields')->willReturn($fields);
 
         $model = $this->getMockBuilder(ModelInterface::class)->getMock();
         $model->expects($this->any())->method('getEntity')->willReturn($entity);
@@ -95,10 +97,12 @@ class CreateTest extends TestCase
         $table = "someTable";
         $idField = "id";
         $data = ['test' => 1, 'some_id' => 2];
+        $fields = ['test', 'some_id'];
 
         $this->expectException(RecordNotFoundException::class);
         $entity = $this->getMockBuilder(EntityInterface::class)->getMock();
         $entity->expects($this->any())->method('getTable')->willReturn($table);
+        $entity->expects($this->any())->method('getAllFields')->willReturn($fields);
 
         $model = $this->getMockBuilder(ModelInterface::class)->getMock();
         $model->expects($this->any())->method('getEntity')->willReturn($entity);

--- a/tests/src/Orm/Events/Persistence/Pdo/UpdateTest.php
+++ b/tests/src/Orm/Events/Persistence/Pdo/UpdateTest.php
@@ -67,11 +67,13 @@ class UpdateTest extends TestCase
     {
         $table = "someTable";
         $data = ['name' => "some", 'street' => "fields"];
+        $fields = ['name', 'street'];
         $idField = "id";
 
         $entity = $this->getMockBuilder(EntityInterface::class)->getMock();
         $entity->expects($this->any())->method('getTable')->willReturn($table);
         $entity->expects($this->any())->method('getIdField')->willReturn($idField);
+        $entity->expects($this->any())->method('getAllFields')->willReturn($fields);
 
         $model = $this->getMockBuilder(ModelInterface::class)->getMock();
         $model->expects($this->any())->method('getEntity')->willReturn($entity);
@@ -91,17 +93,20 @@ class UpdateTest extends TestCase
 
         $this->assertNull($this->object->setUpdate($select)->onExecute($event));
     }
+
     public function testOnExecuteNoRecord()
     {
         $table = "someTable";
         $data = ['name' => "some", 'street' => "fields"];
+        $fields = ['name', 'street'];
         $idField = "id";
 
-        
+
         $this->expectException(RecordNotFoundException::class);
         $entity = $this->getMockBuilder(EntityInterface::class)->getMock();
         $entity->expects($this->any())->method('getTable')->willReturn($table);
         $entity->expects($this->any())->method('getIdField')->willReturn($idField);
+        $entity->expects($this->any())->method('getAllFields')->willReturn($fields);
 
         $model = $this->getMockBuilder(ModelInterface::class)->getMock();
         $model->expects($this->any())->method('getEntity')->willReturn($entity);


### PR DESCRIPTION
#### Fixes
Fixes #109 

#### Changes proposed in this pull request:
- Add a method to reduce fields to just the ones approved by the entity.

#### Checklist
*place an x confirming all items have been verified*
- [x]  Unit tests coverage exceeds or maintains current levels (run command: ```composer test```)
- [x]  Code Sniffer has reported zero issues (run command: ```composer inspect```)
- [x]  Documentation is thorough and rich in content
