### PR TITLE
Add a password validation event

### DIFF
--- a/src/Orm/Entity/HasPasswordInterface.php
+++ b/src/Orm/Entity/HasPasswordInterface.php
@@ -22,48 +22,24 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-namespace DSchoenbauer\Orm\Enum;
+namespace DSchoenbauer\Orm\Entity;
+
+use DSchoenbauer\Orm\Events\Filter\PasswordMask\PasswordMaskStrategyInterface;
 
 /**
- * An enumerated list of values used to define events a model may trigger
  *
  * @author David Schoenbauer
  */
-class ModelEvents
+interface HasPasswordInterface extends EntityInterface
 {
-    
+
     /**
-     * Called to create a new record
+     * @return PasswordMaskStrategyInterface A process for encrypting and
+     * verifying passwords.
      */
-    const CREATE = 'create';
+    public function getPasswordMaskStrategy();
+
+    public function getUserNameField();
     
-    /**
-     * Called to retrieve a given record
-     */
-    const FETCH = "fetch";
-    
-    /**
-     * Called to retrieve a collection of records
-     */
-    const FETCH_ALL = "fetchAll";
-    
-    /**
-     * Called to update a record with data
-     */
-    const UPDATE = 'update';
-    
-    /**
-     * Called to remove data, be it one or many records
-     */
-    const DELETE = 'delete';
-    
-    /**
-     * Event called when an exception occurs
-     */
-    const ERROR = 'error';
-    
-    /**
-     * Event called when authorization has been verified the first time
-     */
-    const AUTHENTICATION_SUCCESS = 'authentication_success';
+    public function getPasswordField();
 }

--- a/src/Orm/Events/Filter/PasswordMask.php
+++ b/src/Orm/Events/Filter/PasswordMask.php
@@ -1,0 +1,61 @@
+<?php
+/*
+ * The MIT License
+ *
+ * Copyright 2017 David Schoenbauer.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+namespace DSchoenbauer\Orm\Events\Filter;
+
+use DSchoenbauer\Orm\Entity\HasPasswordInterface;
+use DSchoenbauer\Orm\Events\AbstractEvent;
+use DSchoenbauer\Orm\Events\Filter\PasswordMask\PasswordMaskStrategyInterface;
+use DSchoenbauer\Orm\ModelInterface;
+use Zend\EventManager\EventInterface;
+
+/**
+ * Masks incoming passwords with the appropriate strategy
+ */
+class PasswordMask extends AbstractEvent
+{
+
+    public function onExecute(EventInterface $event)
+    {
+        /* @var $model ModelInterface */
+        $model = $event->getTarget();
+        if (!$this->validateModel($model, HasPasswordInterface::class)) {
+            return false;
+        }
+        /* @var $entity HasPasswordInterface */
+        $entity = $model->getEntity();
+        $data = $model->getData();
+        $field = $entity->getPasswordField();
+        $model->setData($this->obfascateData($data, $field, $entity->getPasswordMaskStrategy()));
+        return true;
+    }
+
+    public function obfascateData(array $data, $field, PasswordMaskStrategyInterface $passwordMasker)
+    {
+        if (array_key_exists($field, $data)) {
+            $data[$field] = $passwordMasker->hashString($data[$field]);
+        }
+        return $data;
+    }
+}

--- a/src/Orm/Events/Filter/PasswordMask/BlowFishPasswordStrategy.php
+++ b/src/Orm/Events/Filter/PasswordMask/BlowFishPasswordStrategy.php
@@ -22,48 +22,40 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-namespace DSchoenbauer\Orm\Enum;
+namespace DSchoenbauer\Orm\Events\Filter\PasswordMask;
 
 /**
- * An enumerated list of values used to define events a model may trigger
+ * Description of BlowFishPasswordStrategy
  *
  * @author David Schoenbauer
  */
-class ModelEvents
+class BlowFishPasswordStrategy implements PasswordMaskStrategyInterface
 {
-    
-    /**
-     * Called to create a new record
-     */
-    const CREATE = 'create';
-    
-    /**
-     * Called to retrieve a given record
-     */
-    const FETCH = "fetch";
-    
-    /**
-     * Called to retrieve a collection of records
-     */
-    const FETCH_ALL = "fetchAll";
-    
-    /**
-     * Called to update a record with data
-     */
-    const UPDATE = 'update';
-    
-    /**
-     * Called to remove data, be it one or many records
-     */
-    const DELETE = 'delete';
-    
-    /**
-     * Event called when an exception occurs
-     */
-    const ERROR = 'error';
-    
-    /**
-     * Event called when authorization has been verified the first time
-     */
-    const AUTHENTICATION_SUCCESS = 'authentication_success';
+    private $cost = 10;
+
+    public function __construct($cost = 10)
+    {
+        $this->setCost($cost);
+    }
+
+    public function hashString($string)
+    {
+        return password_hash($string, PASSWORD_BCRYPT, ['cost' => $this->getCost()]);
+    }
+
+    public function validate($string, $hash)
+    {
+        return password_verify($string, $hash);
+    }
+
+    public function getCost()
+    {
+        return $this->cost;
+    }
+
+    public function setCost($cost)
+    {
+        $this->cost = $cost;
+        return $this;
+    }
 }

--- a/src/Orm/Events/Filter/PasswordMask/MD5PasswordStrategy.php
+++ b/src/Orm/Events/Filter/PasswordMask/MD5PasswordStrategy.php
@@ -22,48 +22,41 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-namespace DSchoenbauer\Orm\Enum;
+namespace DSchoenbauer\Orm\Events\Filter\PasswordMask;
 
 /**
- * An enumerated list of values used to define events a model may trigger
+ * Description of MD5PasswordStratgey
  *
  * @author David Schoenbauer
  */
-class ModelEvents
+class MD5PasswordStrategy implements PasswordMaskStrategyInterface
 {
-    
-    /**
-     * Called to create a new record
-     */
-    const CREATE = 'create';
-    
-    /**
-     * Called to retrieve a given record
-     */
-    const FETCH = "fetch";
-    
-    /**
-     * Called to retrieve a collection of records
-     */
-    const FETCH_ALL = "fetchAll";
-    
-    /**
-     * Called to update a record with data
-     */
-    const UPDATE = 'update';
-    
-    /**
-     * Called to remove data, be it one or many records
-     */
-    const DELETE = 'delete';
-    
-    /**
-     * Event called when an exception occurs
-     */
-    const ERROR = 'error';
-    
-    /**
-     * Event called when authorization has been verified the first time
-     */
-    const AUTHENTICATION_SUCCESS = 'authentication_success';
+
+    private $salt;
+
+    public function __construct($salt = null)
+    {
+        $this->setSalt($salt);
+    }
+
+    public function hashString($string)
+    {
+        return md5($this->getSalt() . $string);
+    }
+
+    public function validate($string, $hash)
+    {
+        return $this->hashString($string) === $hash;
+    }
+
+    public function getSalt()
+    {
+        return $this->salt;
+    }
+
+    public function setSalt($salt)
+    {
+        $this->salt = $salt;
+        return $this;
+    }
 }

--- a/src/Orm/Events/Filter/PasswordMask/PasswordMaskStrategyInterface.php
+++ b/src/Orm/Events/Filter/PasswordMask/PasswordMaskStrategyInterface.php
@@ -22,48 +22,23 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-namespace DSchoenbauer\Orm\Enum;
+namespace DSchoenbauer\Orm\Events\Filter\PasswordMask;
 
 /**
- * An enumerated list of values used to define events a model may trigger
  *
  * @author David Schoenbauer
  */
-class ModelEvents
+interface PasswordMaskStrategyInterface
 {
-    
     /**
-     * Called to create a new record
+     * @param string $string
+     * @return string
      */
-    const CREATE = 'create';
-    
+    public function hashString($string);
+
     /**
-     * Called to retrieve a given record
+     * @param string $password
+     * @return bool
      */
-    const FETCH = "fetch";
-    
-    /**
-     * Called to retrieve a collection of records
-     */
-    const FETCH_ALL = "fetchAll";
-    
-    /**
-     * Called to update a record with data
-     */
-    const UPDATE = 'update';
-    
-    /**
-     * Called to remove data, be it one or many records
-     */
-    const DELETE = 'delete';
-    
-    /**
-     * Event called when an exception occurs
-     */
-    const ERROR = 'error';
-    
-    /**
-     * Event called when authorization has been verified the first time
-     */
-    const AUTHENTICATION_SUCCESS = 'authentication_success';
+    public function validate($password, $hash);
 }

--- a/src/Orm/Events/Filter/PasswordMask/Sha1PasswordStrategy.php
+++ b/src/Orm/Events/Filter/PasswordMask/Sha1PasswordStrategy.php
@@ -22,48 +22,41 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-namespace DSchoenbauer\Orm\Enum;
+namespace DSchoenbauer\Orm\Events\Filter\PasswordMask;
 
 /**
- * An enumerated list of values used to define events a model may trigger
+ * Description of Sha1PasswordStrategy
  *
  * @author David Schoenbauer
  */
-class ModelEvents
+class Sha1PasswordStrategy implements PasswordMaskStrategyInterface
 {
+
+    private $salt;
+
+    public function __construct($salt = null)
+    {
+        $this->setSalt($salt);
+    }
+
+    public function hashString($string)
+    {
+        return sha1($this->getSalt() . $string);
+    }
+
+    public function validate($password, $hash)
+    {
+        return $hash === $this->hashString($password);
+    }
     
-    /**
-     * Called to create a new record
-     */
-    const CREATE = 'create';
-    
-    /**
-     * Called to retrieve a given record
-     */
-    const FETCH = "fetch";
-    
-    /**
-     * Called to retrieve a collection of records
-     */
-    const FETCH_ALL = "fetchAll";
-    
-    /**
-     * Called to update a record with data
-     */
-    const UPDATE = 'update';
-    
-    /**
-     * Called to remove data, be it one or many records
-     */
-    const DELETE = 'delete';
-    
-    /**
-     * Event called when an exception occurs
-     */
-    const ERROR = 'error';
-    
-    /**
-     * Event called when authorization has been verified the first time
-     */
-    const AUTHENTICATION_SUCCESS = 'authentication_success';
+    public function getSalt()
+    {
+        return $this->salt;
+    }
+
+    public function setSalt($salt)
+    {
+        $this->salt = $salt;
+        return $this;
+    }
 }

--- a/src/Orm/Events/Filter/PasswordValidate.php
+++ b/src/Orm/Events/Filter/PasswordValidate.php
@@ -1,0 +1,124 @@
+<?php
+/*
+ * The MIT License
+ *
+ * Copyright 2017 David Schoenbauer.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+namespace DSchoenbauer\Orm\Events\Filter;
+
+use DSchoenbauer\Exception\Http\ClientError\UnauthorizedException;
+use DSchoenbauer\Orm\Entity\HasPasswordInterface;
+use DSchoenbauer\Orm\Enum\EventPriorities;
+use DSchoenbauer\Orm\Enum\ModelEvents;
+use DSchoenbauer\Orm\Events\AbstractEvent;
+use DSchoenbauer\Orm\ModelInterface;
+use DSchoenbauer\Sql\Command\Select;
+use DSchoenbauer\Sql\Where\ArrayWhere;
+use PDO;
+use Zend\EventManager\EventInterface;
+
+/**
+ * Description of PasswordValidate
+ *
+ * @author David Schoenbauer
+ */
+class PasswordValidate extends AbstractEvent
+{
+
+    private $adapter;
+    private $select;
+
+    public function __construct(array $events, PDO $adapter, $priority = EventPriorities::ON_TIME)
+    {
+        $this->setAdapter($adapter);
+        parent::__construct($events, $priority);
+    }
+
+    public function onExecute(EventInterface $event)
+    {
+        /* @var $model ModelInterface */
+        $model = $event->getTarget();
+        if (!$this->validateModel($model, HasPasswordInterface::class)) {
+            return false;
+        }
+        /* @var $entity HasPasswordInterface */
+        $entity = $model->getEntity();
+        if (!$this->validateUser($model->getData(), $entity)) {
+            throw new UnauthorizedException();
+        }
+        $model->getEventManager()->trigger(ModelEvents::AUTHENTICATION_SUCCESS, $model);
+        return true;
+    }
+
+    public function validateUser($data, HasPasswordInterface $passwordInfo)
+    {
+        if (!array_key_exists($passwordInfo->getPasswordField(), $data ?: []) ||
+            !array_key_exists($passwordInfo->getUserNameField(), $data ?: [])
+        ) {
+            return false;
+        }
+        $hash = $this->getUsersPasswordHash($data[$passwordInfo->getUserNameField()], $passwordInfo);
+        return $passwordInfo->getPasswordMaskStrategy()->validate($data[$passwordInfo->getPasswordField()], $hash);
+    }
+
+    public function getUsersPasswordHash($userName, HasPasswordInterface $passwordInfo)
+    {
+        return $this->getSelect()
+            ->setTable($passwordInfo->getTable())
+            ->setFields([$passwordInfo->getPasswordField()])
+            ->setWhere(new ArrayWhere([$passwordInfo->getUserNameField() => $userName]))
+            ->setFetchFlat()
+            ->setFetchStyle(\PDO::FETCH_COLUMN)
+            ->setDefaultValue(false)
+            ->execute($this->getAdapter());
+    }
+
+    /**
+     * @return Select
+     */
+    public function getSelect()
+    {
+        if (!$this->select) {
+            $this->setSelect(new Select(null));
+        }
+        return $this->select;
+    }
+
+    public function setSelect(Select $select)
+    {
+        $this->select = $select;
+        return $this;
+    }
+
+    /**
+     * @return PDO
+     */
+    public function getAdapter()
+    {
+        return $this->adapter;
+    }
+
+    public function setAdapter(PDO $adapter)
+    {
+        $this->adapter = $adapter;
+        return $this;
+    }
+}

--- a/tests/src/Orm/Events/Filter/PasswordMask/BlowFishPasswordStrategyTest.php
+++ b/tests/src/Orm/Events/Filter/PasswordMask/BlowFishPasswordStrategyTest.php
@@ -1,0 +1,106 @@
+<?php
+/*
+ * The MIT License
+ *
+ * Copyright 2017 David Schoenbauer.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+namespace DSchoenbauer\Orm\Events\Filter\PasswordMask;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Description of BlowFishPasswordStrategy
+ *
+ * @author David Schoenbauer
+ */
+class BlowFishPasswordStrategyTest extends TestCase
+{
+
+    private $object;
+
+    protected function setUp()
+    {
+        $this->object = new BlowFishPasswordStrategy();
+    }
+
+    public function testHasProperInterface()
+    {
+        $this->assertInstanceOf(PasswordMaskStrategyInterface::class, $this->object);
+    }
+
+    public function testCost()
+    {
+        $this->assertEquals(10, $this->object->getCost());
+        $this->assertEquals(12, $this->object->setCost(12)->getCost());
+    }
+
+    /**
+     * @dataProvider generalDataProvider
+     */
+    public function testHashString($result, $value, $cost)
+    {
+        $result = $this->object->setCost($cost)->hashString($value);
+        $this->assertEquals(60, strlen($result));
+        $this->assertEquals('$2y$' . str_pad($cost, 2, "0", STR_PAD_LEFT) . '$', substr($result, 0, 7));
+    }
+
+    /**
+     * @dataProvider generalDataProvider
+     */
+    public function testValidate($hash, $string)
+    {
+        $this->assertFalse($this->object->validate('WrongPassword', $hash));
+        $this->assertTrue($this->object->validate($string, $hash));
+    }
+
+    /**
+     * Top 25 passwords of 2016
+     */
+    public function generalDataProvider()
+    {
+        return [
+            ['$2y$04$1T2J6oRR62HxBM8W3uh85O/ILd2raamXlFGu2PIRJVqfPGPggWe8G', '1234567890', 4],
+            ['$2y$05$YY.MVXxRtUMVo3kTVc5GkewkSS068S5wlYoQ06I6Er6N.XbWsWYMi', '123456789', 5],
+            ['$2y$06$rB4pocdInpDdaxHoXgeFtegMtWO0rajreJMISY45dfx38fMpuD9Cm', '123456', 6],
+            ['$2y$04$duFRRG1eTbTg006AFL8ZlOlrjCGwA0FtTQrOtFYRhb5tuneU8xN5G', 'qwerty', 4],
+            ['$2y$05$Ua2WRbT7J0a8UCeh.OGTLuCinM/vYRzWKcwujI7GR401PUGPDWlS2', '12345678', 5],
+            ['$2y$06$1pOMwmT51VkiLfdr1rttDePVFp.9w8SbvY.h.JK1iDXhGVZnYBWjO', '111111', 6],
+            ['$2y$07$E8HBhIo3izEM7imBQWK7R.tR5kFv.2khCYIoQaH.EyuSGADTP1Dle', '1234567', 7],
+            ['$2y$08$zTvjRWjjEQrjKteau1MJ4OU1cMvKPjTwzM5fkEhJr19QDiAqXuRPG', 'password', 8],
+            ['$2y$09$ry/xyCe9ue7wkiR0y7VvCeV1jznchuLOFxhKnOMDuccRzAPBEob7u', '123123', 9],
+            ['$2y$09$4Dz06zP8.j2t06BhyTShUOmWGEXOSkzzjasR/eLWXmSkxNDo5uML6', '987654321', 9],
+            ['$2y$04$f5njDmszvGSBjov4XXxfOewLXeylaG7e5GS8.0QRZufbaGB6OEs7G', 'qwertyuiop', 4],
+            ['$2y$05$n15czAj.cjjHLc5pVZZCRe.iRI0WtEdeJo8oTDSmLRt4OLOFW3lPO', 'mynoob', 5],
+            ['$2y$06$8cs3jTLOA9Fx3gaU3k32ZuhRW6ywOnM8spBkUtZ3rsmfVXvSOnsoy', '123321', 6],
+            ['$2y$04$nirUeLULWWjSXv3.l5.U/ebzGhDpvc2Wy2codQjBpm7nRZ9QEg/Su', '666666', 4],
+            ['$2y$05$dh62fEVbrq.SfMMY9TEiNeAzLCosDz3/a5caABiM8PScB2EJV/S.y', '18atcskd2w', 5],
+            ['$2y$06$WYMe3yR/iouhUR7GQ0wZtevyjsLjs1reT/O.W8kIA1IO3RdoOxW6S', '7777777', 6],
+            ['$2y$07$0YGmgH8GF91r.J7/WtInPeoGetjGJXgh9U72a8emA2fiU29QpQDrK', '1q2w3e4r', 7],
+            ['$2y$08$Xu.HGAoWdTpiO5JfsaFEGuH/HNy3vgM2gRIHSLzQdyNU0uOYxT1ty', '654321', 8],
+            ['$2y$09$v.RP127GKdzbAqJe3b.mWOnWiBmnEa5BS08.kxTv7QTW89NS1aCZ.', '555555', 9],
+            ['$2y$07$tBizGPDLORj8Ba/r9QoQYOuvlBERP0valLwkmV5uOtK3BNRY70xH.', '3rjs1la7qe', 7],
+            ['$2y$04$iicwoNuqmAda5PhXmX6pHeLIITgglQ/FBEk9wqb8BpAPJaQTwhVEe', 'google', 4],
+            ['$2y$05$Cm.ezmdDHhu9kRoJyZRl0ulJTRkapBRnUMP5lcb1BJSwjjKGHgJre', '1q2w3e4r5t', 5],
+            ['$2y$05$CMbtd4Ht7/nRVgdAlteYeOkaEe3S5W57H3xp5dKcFpWa8GjhYOVjm', '123qwe', 5],
+            ['$2y$04$lQ6aA1McV/WaHQtCB0ZPu.CbzFvR.hhiDZl/53DJmuJCcuarbd0AC', 'zxcvbnm', 4]
+        ];
+    }
+}

--- a/tests/src/Orm/Events/Filter/PasswordMask/MD5PasswordStrategyTest.php
+++ b/tests/src/Orm/Events/Filter/PasswordMask/MD5PasswordStrategyTest.php
@@ -1,0 +1,130 @@
+<?php
+/*
+ * The MIT License
+ *
+ * Copyright 2017 David Schoenbauer.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+namespace DSchoenbauer\Orm\Events\Filter\PasswordMask;
+
+/**
+ * Description of MD5PasswordStratgeyTest
+ *
+ * @author David Schoenbauer
+ */
+class MD5PasswordStrategyTest extends \PHPUnit\Framework\TestCase
+{
+
+    /**
+     * @var MD5PasswordStrategy
+     */
+    private $object;
+
+    protected function setUp()
+    {
+        $this->object = new MD5PasswordStrategy();
+    }
+
+    /**
+     * @dataProvider generalDataProvider
+     * @param type $password
+     */
+    public function testHashString($password)
+    {
+        $this->assertEquals(md5($password), $this->object->hashString($password));
+    }
+
+    /**
+     * @dataProvider generalDataProvider
+     * @param type $password
+     */
+    public function testValidateGood($password)
+    {
+        $this->assertTrue($this->object->validate($password, md5($password)));
+    }
+
+    /**
+     * @dataProvider generalDataProvider
+     * @param type $password
+     */
+    public function testValidateError($password)
+    {
+        $this->assertFalse($this->object->validate($password, md5($password . '-with-salt')));
+    }
+
+    public function testSalt()
+    {
+        $this->assertEquals('test', $this->object->setSalt('test')->getSalt());
+    }
+
+    /**
+     * @dataProvider generalDataProvider
+     * @param type $password
+     */
+    public function testSaltedHashString($password)
+    {
+        $salt = 'salt';
+        $this->assertEquals(md5($salt . $password), $this->object->setSalt($salt)->hashString($password));
+    }
+
+    /**
+     * @dataProvider generalDataProvider
+     * @param type $password
+     */
+    public function testSaltedValidate($password)
+    {
+        $salt = 'salt';
+        $this->assertFalse($this->object->setSalt($salt)->validate($password, md5($password)));
+        $this->assertTrue($this->object->setSalt($salt)->validate($password, md5($salt . $password)));
+    }
+
+    /**
+     * Top 25 passwords of 2016
+     */
+    public function generalDataProvider()
+    {
+        return [
+            ['1234567890'],
+            ['123456789'],
+            ['123456'],
+            ['qwerty'],
+            ['12345678'],
+            ['111111'],
+            ['1234567'],
+            ['password'],
+            ['123123'],
+            ['987654321'],
+            ['qwertyuiop'],
+            ['mynoob'],
+            ['123321'],
+            ['666666'],
+            ['18atcskd2w'],
+            ['7777777'],
+            ['1q2w3e4r'],
+            ['654321'],
+            ['555555'],
+            ['3rjs1la7qe'],
+            ['google'],
+            ['1q2w3e4r5t'],
+            ['123qwe'],
+            ['zxcvbnm'],
+            ['1q2w3e']];
+    }
+}

--- a/tests/src/Orm/Events/Filter/PasswordMask/Sha1PasswordStrategyTest.php
+++ b/tests/src/Orm/Events/Filter/PasswordMask/Sha1PasswordStrategyTest.php
@@ -1,0 +1,126 @@
+<?php
+/*
+ * The MIT License
+ *
+ * Copyright 2017 David Schoenbauer.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+namespace DSchoenbauer\Orm\Events\Filter\PasswordMask;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Description of Sha1PasswordStrategyTest
+ *
+ * @author David Schoenbauer
+ */
+class Sha1PasswordStrategyTest extends TestCase
+{
+
+    private $object;
+
+    protected function setUp()
+    {
+        $this->object = new Sha1PasswordStrategy();
+    }
+
+    public function testHasProperInterface()
+    {
+        $this->assertInstanceOf(PasswordMaskStrategyInterface::class, $this->object);
+    }
+
+    /**
+     * 
+     * @dataProvider generalDataProvider
+     */
+    public function testHashString($password)
+    {
+        $this->assertEquals(sha1($password), $this->object->hashString($password));
+    }
+
+    /**
+     * 
+     * @dataProvider generalDataProvider
+     */
+    public function testValidate($password)
+    {
+        $this->assertTrue($this->object->validate($password, sha1($password)));
+        $this->assertFalse($this->object->validate($password, sha1($password . 'salt?')));
+    }
+
+    public function testSalt()
+    {
+        $this->assertEquals('test', $this->object->setSalt('test')->getSalt());
+    }
+
+    /**
+     * @dataProvider generalDataProvider
+     * @param type $password
+     */
+    public function testSaltedHashString($password)
+    {
+        $salt = 'salt';
+        $this->assertEquals(sha1($salt . $password), $this->object->setSalt($salt)->hashString($password));
+    }
+
+    /**
+     * @dataProvider generalDataProvider
+     * @param type $password
+     */
+    public function testSaltedValidate($password)
+    {
+        $salt = 'salt';
+        $this->assertFalse($this->object->setSalt($salt)->validate($password, sha1($password)));
+        $this->assertTrue($this->object->setSalt($salt)->validate($password, sha1($salt . $password)));
+    }
+
+    /**
+     * Top 25 passwords of 2016
+     */
+    public function generalDataProvider()
+    {
+        return [
+            ['1234567890'],
+            ['123456789'],
+            ['123456'],
+            ['qwerty'],
+            ['12345678'],
+            ['111111'],
+            ['1234567'],
+            ['password'],
+            ['123123'],
+            ['987654321'],
+            ['qwertyuiop'],
+            ['mynoob'],
+            ['123321'],
+            ['666666'],
+            ['18atcskd2w'],
+            ['7777777'],
+            ['1q2w3e4r'],
+            ['654321'],
+            ['555555'],
+            ['3rjs1la7qe'],
+            ['google'],
+            ['1q2w3e4r5t'],
+            ['123qwe'],
+            ['zxcvbnm'],
+            ['1q2w3e']];
+    }
+}

--- a/tests/src/Orm/Events/Filter/PasswordMaskTest.php
+++ b/tests/src/Orm/Events/Filter/PasswordMaskTest.php
@@ -1,0 +1,111 @@
+<?php
+/*
+ * The MIT License
+ *
+ * Copyright 2017 David Schoenbauer.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+namespace DSchoenbauer\Orm\Events\Filter;
+
+use DSchoenbauer\Orm\Entity\HasPasswordInterface;
+use DSchoenbauer\Orm\Events\AbstractEvent;
+use DSchoenbauer\Orm\Events\Filter\PasswordMask\PasswordMaskStrategyInterface;
+use DSchoenbauer\Orm\ModelInterface;
+use PHPUnit\Framework\TestCase;
+use Zend\EventManager\EventInterface;
+
+/**
+ * Description of PasswordMaskTest
+ *
+ * @author David Schoenbauer
+ */
+class PasswordMaskTest extends TestCase
+{
+
+    private $object;
+
+    protected function setUp()
+    {
+        $this->object = new PasswordMask();
+    }
+
+    public function testHasProperLineage()
+    {
+        $this->assertInstanceOf(AbstractEvent::class, $this->object);
+    }
+
+    public function testExecuteNoModel()
+    {
+        $event = $this->getMockBuilder(EventInterface::class)->getMock();
+        $this->assertFalse($this->object->onExecute($event));
+    }
+
+    public function testExecuteModelNoEntity()
+    {
+        $model = $this->getMockBuilder(ModelInterface::class)->getMock();
+        $model->expects($this->once())->method('getEntity');
+
+        $event = $this->getMockBuilder(EventInterface::class)->getMock();
+        $event->expects($this->any())->method('getTarget')->willReturn($model);
+
+        $this->assertFalse($this->object->onExecute($event));
+    }
+
+    public function testExecuteAllGood()
+    {
+
+        $passwordMask = $this->getMockBuilder(PasswordMaskStrategyInterface::class)->getMock();
+
+        $entity = $this->getMockBuilder(HasPasswordInterface::class)->getMock();
+        $entity->expects($this->any())->method('getPasswordMaskStrategy')->willReturn($passwordMask);
+
+
+        $model = $this->getMockBuilder(ModelInterface::class)->getMock();
+        $model->expects($this->any())->method('getEntity')->willReturn($entity);
+        $model->expects($this->once())->method('getData')->willReturn(['test' => 'test']);
+        $model->expects($this->once())->method('setData');
+
+        $event = $this->getMockBuilder(EventInterface::class)->getMock();
+        $event->expects($this->any())->method('getTarget')->willReturn($model);
+
+
+
+        $this->assertTrue($this->object->onExecute($event));
+    }
+
+    public function testObfascateDataPresent()
+    {
+        $data = ['name' => 'bob', 'password' => 'test'];
+        $dataResult = ['name' => 'bob', 'password' => 'secret'];
+        $field = 'password';
+        $passwordMasker = $this->getMockBuilder(PasswordMaskStrategyInterface::class)->getMock();
+        $passwordMasker->expects($this->once())->method('hashString')->with('test')->willReturn('secret');
+        $this->assertEquals($dataResult, $this->object->obfascateData($data, $field, $passwordMasker));
+    }
+
+    public function testObfascateDataMissing()
+    {
+        $data = ['name' => 'bob'];
+        $field = 'password';
+        $passwordMasker = $this->getMockBuilder(PasswordMaskStrategyInterface::class)->getMock();
+        $passwordMasker->expects($this->never())->method('hashString');
+        $this->assertEquals($data, $this->object->obfascateData($data, $field, $passwordMasker));
+    }
+}

--- a/tests/src/Orm/Events/Filter/PasswordValidateTest.php
+++ b/tests/src/Orm/Events/Filter/PasswordValidateTest.php
@@ -1,0 +1,196 @@
+<?php
+/*
+ * The MIT License
+ *
+ * Copyright 2017 David Schoenbauer.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+namespace DSchoenbauer\Orm\Events\Filter;
+
+use DSchoenbauer\Exception\Http\ClientError\UnauthorizedException;
+use DSchoenbauer\Orm\Entity\HasPasswordInterface;
+use DSchoenbauer\Orm\Events\AbstractEvent;
+use DSchoenbauer\Orm\Events\Filter\PasswordMask\PasswordMaskStrategyInterface;
+use DSchoenbauer\Orm\ModelInterface;
+use DSchoenbauer\Sql\Command\Select;
+use DSchoenbauer\Sql\Where\ArrayWhere;
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Zend\EventManager\EventInterface;
+use Zend\EventManager\EventManager;
+
+/**
+ * Description of PasswordValidateTest
+ *
+ * @author David Schoenbauer
+ */
+class PasswordValidateTest extends TestCase
+{
+    /* @var $object PasswordValidate */
+
+    private $object;
+
+    protected function setUp()
+    {
+        $pdo = $this->getMockBuilder(PDO::class)->disableOriginalConstructor()->getMock();
+        $this->object = new PasswordValidate([], $pdo);
+    }
+
+    public function testHasProperLineage()
+    {
+        $this->assertInstanceOf(AbstractEvent::class, $this->object);
+    }
+
+    public function testExecuteNoModel()
+    {
+        $event = $this->getMockBuilder(EventInterface::class)->getMock();
+        $this->assertFalse($this->object->onExecute($event));
+    }
+
+    public function testExecuteModelNoEntity()
+    {
+        $model = $this->getMockBuilder(ModelInterface::class)->getMock();
+        $model->expects($this->once())->method('getEntity');
+
+        $event = $this->getMockBuilder(EventInterface::class)->getMock();
+        $event->expects($this->any())->method('getTarget')->willReturn($model);
+
+        $this->assertFalse($this->object->onExecute($event));
+    }
+
+    public function testExecuteAllGood()
+    {
+        $this->object = $this->getMockBuilder(PasswordValidate::class)->setMethods(['validateUser'])->disableOriginalConstructor()->getMock();
+        $this->object->expects($this->any())->method('validateUser')->willReturn(true);
+        $passwordMask = $this->getMockBuilder(PasswordMaskStrategyInterface::class)->getMock();
+
+        $entity = $this->getMockBuilder(HasPasswordInterface::class)->getMock();
+        $entity->expects($this->any())->method('getPasswordMaskStrategy')->willReturn($passwordMask);
+
+        $eventManager = $this->getMockBuilder(EventManager::class)->getMock();
+        $eventManager->expects($this->atLeast(1))->method('trigger');
+
+        $model = $this->getMockBuilder(ModelInterface::class)->getMock();
+        $model->expects($this->any())->method('getEntity')->willReturn($entity);
+        $model->expects($this->once())->method('getData')->willReturn(['test' => 'test']);
+        $model->expects($this->once())->method('getEventManager')->willReturn($eventManager);
+
+        $event = $this->getMockBuilder(EventInterface::class)->getMock();
+        $event->expects($this->any())->method('getTarget')->willReturn($model);
+
+        $this->assertTrue($this->object->onExecute($event));
+    }
+
+    public function testExecuteBadUser()
+    {
+        
+        $this->object = $this->getMockBuilder(PasswordValidate::class)->setMethods(['validateUser'])->disableOriginalConstructor()->getMock();
+        $this->object->expects($this->any())->method('validateUser')->willReturn(false);
+        $passwordMask = $this->getMockBuilder(PasswordMaskStrategyInterface::class)->getMock();
+
+        $entity = $this->getMockBuilder(HasPasswordInterface::class)->getMock();
+        $entity->expects($this->any())->method('getPasswordMaskStrategy')->willReturn($passwordMask);
+
+
+        $model = $this->getMockBuilder(ModelInterface::class)->getMock();
+        $model->expects($this->any())->method('getEntity')->willReturn($entity);
+        $model->expects($this->once())->method('getData')->willReturn(['test' => 'test']);
+
+        $event = $this->getMockBuilder(EventInterface::class)->getMock();
+        $event->expects($this->any())->method('getTarget')->willReturn($model);
+
+        $this->expectException(UnauthorizedException::class);
+        $this->object->onExecute($event);
+    }
+
+    public function testValidateUserDataNotPresent()
+    {
+        $passwordInfo = $this->getMockBuilder(HasPasswordInterface::class)->getMock();
+        $passwordInfo->expects($this->any())->method('getUserNameField')->willReturn('user');
+        $passwordInfo->expects($this->any())->method('getPasswordField')->willReturn('pass');
+
+
+        $this->assertFalse($this->object->validateUser(null, $passwordInfo), 'No user info');
+        $this->assertFalse($this->object->validateUser([], $passwordInfo), 'No user info');
+        $this->assertFalse($this->object->validateUser(['name' => 'bob'], $passwordInfo), 'No user info');
+        $this->assertFalse($this->object->validateUser(['pass' => 'test'], $passwordInfo), 'No user');
+        $this->assertFalse($this->object->validateUser(['user' => 'test'], $passwordInfo), 'No password');
+    }
+
+    public function testValidateUserAll()
+    {
+
+        $this->object = $this->getMockBuilder(PasswordValidate::class)->setMethods(['getUsersPasswordHash'])->disableOriginalConstructor()->getMock();
+        $this->object->expects($this->any())->method('getUsersPasswordHash');
+
+        $passwordMaskStrategy = $this->getMockBuilder(PasswordMaskStrategyInterface::class)->getMock();
+        $passwordMaskStrategy->expects($this->once())->method('validate')->willReturn(true);
+
+        $passwordInfo = $this->getMockBuilder(HasPasswordInterface::class)->getMock();
+        $passwordInfo->expects($this->any())->method('getUserNameField')->willReturn('user');
+        $passwordInfo->expects($this->any())->method('getPasswordField')->willReturn('pass');
+        $passwordInfo->expects($this->any())->method('getPasswordMaskStrategy')->willReturn($passwordMaskStrategy);
+
+        $this->assertTrue($this->object->validateUser(['user' => 'test', 'pass' => 'test'], $passwordInfo));
+    }
+
+    public function testAdapter()
+    {
+        $pdo = $this->getMockBuilder(PDO::class)->disableOriginalConstructor()->getMock();
+        $this->assertSame($pdo, $this->object->setAdapter($pdo)->getAdapter());
+    }
+
+    public function testSelect()
+    {
+        $mySelect = $this->getMockBuilder(Select::class)->disableOriginalConstructor()->getMock();
+
+        $lazy = $this->object->getSelect();
+        $this->assertInstanceOf(Select::class, $this->object->getSelect());
+        $this->assertSame($lazy, $this->object->getSelect());
+
+        $this->assertSame($mySelect, $this->object->setSelect($mySelect)->getSelect());
+    }
+
+    public function testGetUsersPasswordHash()
+    {
+        $userName = "test";
+        $table = 'table';
+        $passwordField = 'passwordField';
+        $userNameField = 'userNameField';
+
+        $passwordInfo = $this->getMockBuilder(HasPasswordInterface::class)->getMock();
+        $passwordInfo->expects($this->any())->method('getTable')->willReturn($table);
+        $passwordInfo->expects($this->any())->method('getPasswordField')->willReturn($passwordField);
+        $passwordInfo->expects($this->any())->method('getUserNameField')->willReturn($userNameField);
+
+        $select = $this->getMockBuilder(Select::class)->disableOriginalConstructor()
+            //->setMethods(['setTable','setFields','setWhere','setFetchFlat','setFetchStyle','setDefaultValue','execute'])
+            ->getMock();
+        $select->expects($this->atLeast(1))->method('setTable')->with($table)->willReturnSelf();
+        $select->expects($this->atLeast(1))->method('setFields')->with([$passwordField])->willReturnSelf();
+        $select->expects($this->atLeast(1))->method('setWhere')->with($this->isInstanceOf(ArrayWhere::class))->willReturnSelf(); //Needs to be better
+        $select->expects($this->atLeast(1))->method('setFetchFlat')->willReturnSelf();
+        $select->expects($this->atLeast(1))->method('setFetchStyle')->with(\PDO::FETCH_COLUMN)->willReturnSelf();
+        $select->expects($this->atLeast(1))->method('setDefaultValue')->with(false)->willReturnSelf();
+        $select->expects($this->atLeast(1))->method('execute')->with($this->isInstanceOf(\PDO::class))->willReturn(true);
+
+        $this->assertTrue($this->object->setSelect($select)->getUsersPasswordHash($userName, $passwordInfo));
+    }
+}


### PR DESCRIPTION
Allows for a canned password validation process.

task: #104

#### Fixes
Fixes #104

#### Changes proposed in this pull request:
- Adds event for validating passwords
- Adds MD5, SHA1 and Blowfish (Bcrypt) as password stratgies.
 
#### Checklist
*place an x confirming all items have been verified*
- [x]  Unit tests coverage exceeds or maintains current levels (run command: ```composer test```)
- [x]  Code Sniffer has reported zero issues (run command: ```composer inspect```)
- [x]  Documentation is thorough and rich in content
