### PR TITLE
Add missing required fields to exception message

### DIFF
--- a/src/Orm/Enum/ExceptionDefaultMessages.php
+++ b/src/Orm/Enum/ExceptionDefaultMessages.php
@@ -1,0 +1,37 @@
+<?php
+/*
+ * The MIT License
+ *
+ * Copyright 2017 David Schoenbauer.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+namespace DSchoenbauer\Orm\Enum;
+
+/**
+ * Description of ExceptionMessages
+ *
+ * @author David Schoenbauer
+ */
+class ExceptionDefaultMessages
+{
+
+    const REQUIRED_FIELD_MISSING_EXCEPTION = "The following fields have been determined to be required "
+        . "but are missing: %s";
+}

--- a/src/Orm/Exception/RequiredFieldMissingException.php
+++ b/src/Orm/Exception/RequiredFieldMissingException.php
@@ -25,6 +25,7 @@
 namespace DSchoenbauer\Orm\Exception;
 
 use DSchoenbauer\Exception\Http\ClientError\BadRequestException;
+use DSchoenbauer\Orm\Enum\ExceptionDefaultMessages;
 
 /**
  * A required field is not present in the data payload
@@ -37,10 +38,19 @@ class RequiredFieldMissingException extends BadRequestException implements OrmEx
 
     protected $missingFields;
 
-    public function __construct(array $missingFields = [], $message = "")
+    public function __construct(array $missingFields = [], $message = null)
     {
         $this->setMissingFields($missingFields);
-        parent::__construct($message);
+        if (!$message) {
+            $message = $this->getDefaultMessage();
+        }
+        parent::__construct($this->interpolateMessage($message, $this->getMissingFields()));
+    }
+
+    public function interpolateMessage($message, $fields, $noFieldsIdentifiedMessage = 'no fields identified')
+    {
+        $fieldString = implode(', ', $fields ?: [$noFieldsIdentifiedMessage]);
+        return sprintf($message, $fieldString);
     }
 
     /**
@@ -61,5 +71,10 @@ class RequiredFieldMissingException extends BadRequestException implements OrmEx
     {
         $this->missingFields = $missingFields;
         return $this;
+    }
+
+    public function getDefaultMessage()
+    {
+        return ExceptionDefaultMessages::REQUIRED_FIELD_MISSING_EXCEPTION;
     }
 }

--- a/tests/files/update.json
+++ b/tests/files/update.json
@@ -1,0 +1,1 @@
+[{"id":0,"name":"Andy"},{"id":1,"name":"Wayne"},{"id":2,"name":"Michael"},{"id":3,"name":"Debra"},{"id":4,"name":"Paul"}]

--- a/tests/src/Orm/Exception/RequiredFieldMissingExceptionTest.php
+++ b/tests/src/Orm/Exception/RequiredFieldMissingExceptionTest.php
@@ -25,14 +25,15 @@
 namespace DSchoenbauer\Orm\Exception;
 
 use DSchoenbauer\Exception\Http\ClientError\BadRequestException;
-use \PHPUnit\Framework\TestCase;
+use DSchoenbauer\Orm\Enum\ExceptionDefaultMessages;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Thrown when a data type is provided other than the required data type
  *
  * @author David Schoenbauer
  */
-class RequiredFieldMissingExceptionTest extends \PHPUnit\Framework\TestCase
+class RequiredFieldMissingExceptionTest extends TestCase
 {
 
     private $object;
@@ -56,5 +57,54 @@ class RequiredFieldMissingExceptionTest extends \PHPUnit\Framework\TestCase
     {
         $this->assertEquals([], $this->object->getMissingFields());
         $this->assertEquals(['test'], $this->object->setMissingFields(['test'])->getMissingFields());
+    }
+
+    public function testCustomMessage()
+    {
+        $message = "My Message";
+        $this->object = new RequiredFieldMissingException([], $message);
+        $this->assertEquals($message, $this->object->getMessage());
+    }
+
+    public function testNoMessageFields()
+    {
+        $expected = sprintf(ExceptionDefaultMessages::REQUIRED_FIELD_MISSING_EXCEPTION, 'name, desc');
+        $this->object = new RequiredFieldMissingException(['name', 'desc']);
+        $this->assertEquals($expected, $this->object->getMessage());
+    }
+
+    public function testNoMessageNoFields()
+    {
+        $expected = sprintf(ExceptionDefaultMessages::REQUIRED_FIELD_MISSING_EXCEPTION, 'no fields identified');
+        $this->object = new RequiredFieldMissingException();
+        $this->assertEquals($expected, $this->object->getMessage());
+    }
+
+    /**
+     * 
+     * @param type $expected
+     * @param type $message
+     * @param array $fields
+     * @dataProvider getDataProvider
+     */
+    public function testInterpolateMessage($expected, $message, array $fields)
+    {
+        $this->assertEquals($expected, $this->object->interpolateMessage($message, $fields));
+    }
+
+    public function getDataProvider()
+    {
+        return [
+            ['this is a test: id', 'this is a test: %s', ['id']],
+            ['this is a test: id, name', 'this is a test: %s', ['id', 'name']]
+        ];
+    }
+
+    public function testCustomMessageWithFields()
+    {
+
+        $this->object = new RequiredFieldMissingException(['id'], 'Field missing: %s');
+        $expected = "Field missing: id";
+        $this->assertEquals($expected, $this->object->getMessage());
     }
 }


### PR DESCRIPTION
task: #103

#### Fixes
Fixes #103

#### Changes proposed in this pull request:
- Updated the exception message to include missing files.

#### Checklist
*place an x confirming all items have been verified*
- [ ]  Unit tests coverage exceeds or maintains current levels (run command: ```composer test```)
- [x]  Code Sniffer has reported zero issues (run command: ```composer inspect```)
- [x]  Documentation is thorough and rich in content
