### PR TITLE
Optimize SHA1 password strategy

### DIFF
--- a/src/Orm/Events/Filter/PasswordMask/Sha1PasswordStrategy.php
+++ b/src/Orm/Events/Filter/PasswordMask/Sha1PasswordStrategy.php
@@ -29,34 +29,11 @@ namespace DSchoenbauer\Orm\Events\Filter\PasswordMask;
  *
  * @author David Schoenbauer
  */
-class Sha1PasswordStrategy implements PasswordMaskStrategyInterface
+class Sha1PasswordStrategy extends MD5PasswordStrategy
 {
-
-    private $salt;
-
-    public function __construct($salt = null)
-    {
-        $this->setSalt($salt);
-    }
 
     public function hashString($string)
     {
         return sha1($this->getSalt() . $string);
-    }
-
-    public function validate($password, $hash)
-    {
-        return $hash === $this->hashString($password);
-    }
-    
-    public function getSalt()
-    {
-        return $this->salt;
-    }
-
-    public function setSalt($salt)
-    {
-        $this->salt = $salt;
-        return $this;
     }
 }


### PR DESCRIPTION
Sha1 and MD5 were identical. No reason to have two classes doing the
same thing. So we had SHA1 extend off of MD5, as MD5 will be the more
popular.

task: #116

#### Fixes
Fixes #116

#### Changes proposed in this pull request:
- Optimize SHA1 by extending off of MD5 strategy
#### Checklist
*place an x confirming all items have been verified*
- [ ]  Unit tests coverage exceeds or maintains current levels (run command: ```composer test```)
- [ ]  Code Sniffer has reported zero issues (run command: ```composer inspect```)
- [ ]  Documentation is thorough and rich in content
