### PR TITLE
Enhance the Crud Model delete to be consistent

### DIFF
--- a/src/Orm/CrudModel.php
+++ b/src/Orm/CrudModel.php
@@ -87,16 +87,10 @@ class CrudModel extends Model
      */
     public function delete($idx)
     {
-        try {
-            $this->setId($idx);
-            $this->getEventManager()->trigger(ModelEvents::DELETE, $this);
-            return true;
-        } catch (Exception $exc) {
-            $this->manageExceptions($exc, ModelEvents::DELETE);
-            return false;
-        }
+        $this->setId($idx)->processEvent(ModelEvents::DELETE);
+        return true;
     }
-
+    
     private function processEvent($event)
     {
         try {

--- a/tests/src/Orm/CrudModelTest.php
+++ b/tests/src/Orm/CrudModelTest.php
@@ -101,7 +101,8 @@ class CrudModelTest extends TestCase
         $this->mockEventManager->expects($this->exactly(2))
             ->method('trigger')
             ->withConsecutive(
-                [ModelEvents::FETCH, $this->object], [ModelEvents::ERROR, $this->object, ['event' => ModelEvents::FETCH, 'exception' => $exc]]
+                [ModelEvents::FETCH, $this->object],
+                [ModelEvents::ERROR, $this->object, ['event' => ModelEvents::FETCH, 'exception' => $exc]]
             )->willReturnCallback(function() use ($exc) {
             static $i = 0;
             if ($i == 0) {
@@ -199,14 +200,15 @@ class CrudModelTest extends TestCase
         $this->mockEventManager->expects($this->exactly(2))
             ->method('trigger')
             ->withConsecutive(
-                [ModelEvents::DELETE, $this->object], [ModelEvents::ERROR, $this->object, ['event' => ModelEvents::DELETE, 'exception' => $exc]]
+                [ModelEvents::DELETE, $this->object], 
+                [ModelEvents::ERROR, $this->object, ['event' => ModelEvents::DELETE, 'exception' => $exc]]
             )->willReturnCallback(function() use ($exc) {
-            static $i = 0;
-            if ($i == 0) {
-                $i++;
-                throw $exc;
-            }
-        });
+                static $i = 0;
+                if ($i == 0) {
+                    $i++;
+                    throw $exc;
+                }
+            });
         $this->object->setEventManager($this->mockEventManager);
         $this->object->delete(1447);
     }


### PR DESCRIPTION
task: #136

#### Fixes
Fixes #136 

#### Changes proposed in this pull request:
- CRUD Model Delete Method is now consistent with the other methods.

#### Checklist
*place an x confirming all items have been verified*
- [x]  Unit tests coverage exceeds or maintains current levels (run command: ```composer test```)
- [x]  Code Sniffer has reported zero issues (run command: ```composer inspect```)
- [x]  Documentation is thorough and rich in content
