### PR TITLE
Remove the method manage exceptions

### DIFF
--- a/src/Orm/CrudModel.php
+++ b/src/Orm/CrudModel.php
@@ -90,19 +90,18 @@ class CrudModel extends Model
         $this->setId($idx)->processEvent(ModelEvents::DELETE);
         return true;
     }
-    
-    private function processEvent($event)
+
+    protected function processEvent($event)
     {
         try {
             $this->getEventManager()->trigger($event, $this);
         } catch (Exception $exc) {
-            $this->manageExceptions($exc, $event);
+            $payload = [
+                'exception' => $exc,
+                'event' => $event,
+            ];
+            $this->getEventManager()->trigger(ModelEvents::ERROR, $this, $payload);
         }
         return $this;
-    }
-
-    private function manageExceptions(\Exception $exception, $event)
-    {
-        $this->getEventManager()->trigger(ModelEvents::ERROR, $this, compact('event', 'exception'));
     }
 }


### PR DESCRIPTION
Removed the method as it was a one liner that offered no functionality,
All other methods are using the same function.

task: #136

#### Fixes
Fixes #136

#### Changes proposed in this pull request:
- removes the manageExceptions method reducing complexity

#### Checklist
*place an x confirming all items have been verified*
- [x]  Unit tests coverage exceeds or maintains current levels (run command: ```composer test```)
- [x]  Code Sniffer has reported zero issues (run command: ```composer inspect```)
- [x]  Documentation is thorough and rich in content
