### PR TITLE
Update the HTTP Persistance to use visitor client

### DIFF
--- a/src/Orm/Builder/Component/RestPersistence.php
+++ b/src/Orm/Builder/Component/RestPersistence.php
@@ -56,21 +56,21 @@ class RestPersistence implements VisitorInterface
         $client = $this->getClient();
         $entity = $model->getEntity();
         if ($entity instanceof HasUriCollection) {
-            $post = new Post([ModelEvents::CREATE], $entity->getUriCollectionMask(), $entity->getHeaders());
+            $post = new Post([ModelEvents::CREATE], $entity->getUriCollectionMask());
             $model->accept($post->setClient($client));
             
-            $get = new Get([ModelEvents::FETCH_ALL], $entity->getUriCollectionMask(), $entity->getHeaders());
+            $get = new Get([ModelEvents::FETCH_ALL], $entity->getUriCollectionMask());
             $model->accept($get->setClient($client));
         }
 
         if ($entity instanceof HasUriEntity) {
-            $get = new Get([ModelEvents::FETCH], $entity->getUriEntityMask(), $entity->getHeaders());
+            $get = new Get([ModelEvents::FETCH], $entity->getUriEntityMask());
             $model->accept($get->setClient($client));
             
-            $put = new Put([ModelEvents::UPDATE], $entity->getUriEntityMask(), $entity->getHeaders());
+            $put = new Put([ModelEvents::UPDATE], $entity->getUriEntityMask());
             $model->accept($put->setClient($client));
             
-            $delete = new Delete([ModelEvents::DELETE], $entity->getUriEntityMask(), $entity->getHeaders());
+            $delete = new Delete([ModelEvents::DELETE], $entity->getUriEntityMask());
             $model->accept($delete->setClient($client));
         }
     }

--- a/src/Orm/Entity/IsHttpInterface.php
+++ b/src/Orm/Entity/IsHttpInterface.php
@@ -24,11 +24,13 @@
  */
 namespace DSchoenbauer\Orm\Entity;
 
+use DSchoenbauer\Orm\Events\Persistence\Http\Client\ClientVisitorInterface;
+
 /**
  *
  * @author David Schoenbauer
  */
-interface IsHttpInterface extends EntityInterface
+interface IsHttpInterface extends EntityInterface, ClientVisitorInterface
 {
-    public function getHeaders();
+    
 }

--- a/src/Orm/Events/Persistence/Http/Client/ClientVisiteeInterface.php
+++ b/src/Orm/Events/Persistence/Http/Client/ClientVisiteeInterface.php
@@ -2,7 +2,7 @@
 /*
  * The MIT License
  *
- * Copyright 2017 David Schoenbauer.
+ * Copyright 2018 David Schoenbauer.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,27 +22,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-namespace DSchoenbauer\Orm\Events\Persistence\Http\Methods;
-
-use DSchoenbauer\Orm\ModelInterface;
-use Zend\Http\Request;
+namespace DSchoenbauer\Orm\Events\Persistence\Http\Client;
 
 /**
- * Description of Delete
  *
  * @author David Schoenbauer
  */
-class Delete extends AbstractHttpMethodEvent
+interface ClientVisiteeInterface
 {
 
-    public function send(ModelInterface $model)
-    {
-        $response = $this->checkForError($this->getClient()->send());
-        return $response->isSuccess();
-    }
-
-    public function getMethod()
-    {
-        return Request::METHOD_DELETE;
-    }
+    public function accept(ClientVisitorInterface $visitor);
 }

--- a/src/Orm/Events/Persistence/Http/Client/ClientVisitorInterface.php
+++ b/src/Orm/Events/Persistence/Http/Client/ClientVisitorInterface.php
@@ -2,7 +2,7 @@
 /*
  * The MIT License
  *
- * Copyright 2017 David Schoenbauer.
+ * Copyright 2018 David Schoenbauer.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,27 +22,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-namespace DSchoenbauer\Orm\Events\Persistence\Http\Methods;
+namespace DSchoenbauer\Orm\Events\Persistence\Http\Client;
 
-use DSchoenbauer\Orm\ModelInterface;
-use Zend\Http\Request;
+use Zend\Http\Client;
 
 /**
- * Description of Delete
  *
  * @author David Schoenbauer
  */
-class Delete extends AbstractHttpMethodEvent
+interface ClientVisitorInterface
 {
-
-    public function send(ModelInterface $model)
-    {
-        $response = $this->checkForError($this->getClient()->send());
-        return $response->isSuccess();
-    }
-
-    public function getMethod()
-    {
-        return Request::METHOD_DELETE;
-    }
+    public function visitClient(Client $client);
 }

--- a/src/Orm/Events/Persistence/Http/Methods/Get.php
+++ b/src/Orm/Events/Persistence/Http/Methods/Get.php
@@ -34,10 +34,14 @@ use Zend\Http\Request;
  */
 class Get extends AbstractHttpMethodEvent
 {
-    
+
     public function send(ModelInterface $model)
     {
-        $this->getClient()->setMethod(Request::METHOD_GET)->setUri($this->getUri($model->getData()));
         $model->setData($this->getDataExtractorFactory()->getData($this->checkForError($this->getClient()->send())));
+    }
+
+    public function getMethod()
+    {
+        return Request::METHOD_GET;
     }
 }

--- a/src/Orm/Events/Persistence/Http/Methods/Post.php
+++ b/src/Orm/Events/Persistence/Http/Methods/Post.php
@@ -37,11 +37,8 @@ class Post extends AbstractHttpMethodEvent
     
     public function send(ModelInterface $model)
     {
-        $data = $model->getData();
-        $response = $this->checkForError($this->getClient()->setMethod($this->getMethod())
-                ->setParameterPost($data)
-                ->setUri($this->getUri($data))
-                ->send());
+        $this->getClient()->setParameterPost($model->getData());
+        $response = $this->checkForError($this->getClient()->send());
         $model->setData($this->getDataExtractorFactory()->getData($response));
     }
     

--- a/tests/src/Orm/Builder/Component/RestPersistenceTest.php
+++ b/tests/src/Orm/Builder/Component/RestPersistenceTest.php
@@ -70,9 +70,7 @@ class RestPersistenceTest extends AbstractComponentTestCase
     public function evaluateVisitModel($entityClass, $calls, $maskMethod)
     {
         $entity = $this->getMockBuilder($entityClass)->getMock();
-        $entity->expects($this->any())->method('getHeaders')->willReturn([]);
         $entity->expects($this->exactly($calls))->method($maskMethod);
-        $entity->expects($this->exactly($calls))->method('getHeaders');
 
         $model = $this->getMockBuilder(ModelInterface::class)->getMock();
         $model->expects($this->exactly($calls))->method('accept')->willReturnSelf();

--- a/tests/src/Orm/Events/Persistence/Http/Methods/DeleteTest.php
+++ b/tests/src/Orm/Events/Persistence/Http/Methods/DeleteTest.php
@@ -58,8 +58,6 @@ class DeleteTest extends TestCase
         $model = $this->getModel(1998, [], $this->getIsHttp(null, 'bobsYouUncle', 'bobsYourAunt'));
 
         $client = $this->getMockBuilder(Client::class)->getMock();
-        $client->expects($this->once())->method('setUri')->with('bobsYouUncle')->willReturnSelf();
-        $client->expects($this->once())->method('setMethod')->with(Request::METHOD_DELETE)->willReturnSelf();
         $client->expects($this->once())->method('send')->willReturn($response);
 
         $this->object->setUriMask('bobsYouUncle')->setClient($client)->send($model);
@@ -75,10 +73,12 @@ class DeleteTest extends TestCase
         $model = $this->getModel(1998, [], $this->getIsHttp(null, 'bobsYouUncle', 'bobsYourAunt'));
 
         $client = $this->getMockBuilder(Client::class)->getMock();
-        $client->expects($this->once())->method('setUri')->with('bobsYouUncle')->willReturnSelf();
-        $client->expects($this->once())->method('setMethod')->with(Request::METHOD_DELETE)->willReturnSelf();
         $client->expects($this->once())->method('send')->willReturn($response);
 
         $this->object->setUriMask('bobsYouUncle')->setClient($client)->send($model);
+    }
+    
+    public function testMethod(){
+        $this->assertEquals(Request::METHOD_DELETE, $this->object->getMethod());
     }
 }

--- a/tests/src/Orm/Events/Persistence/Http/Methods/GetTest.php
+++ b/tests/src/Orm/Events/Persistence/Http/Methods/GetTest.php
@@ -59,8 +59,6 @@ class GetTest extends TestCase
         $model->expects($this->once())->method('setData')->with($data);
 
         $client = $this->getMockBuilder(Client::class)->getMock();
-        $client->expects($this->any())->method('setMethod')->with(Request::METHOD_GET)->willReturnSelf();
-        $client->expects($this->any())->method('setUri')->with('entity')->willReturnSelf();
         $client->expects($this->any())->method('send')->willReturn($this->getResponse('somethingJson', json_encode($data)));
 
         $this->object->setUriMask('entity')->setClient($client)->send($model);
@@ -76,10 +74,13 @@ class GetTest extends TestCase
         $model = $this->getModel(1999, $data, $this->getIsHttp('id', 'entity', 'collection'));
 
         $client = $this->getMockBuilder(Client::class)->getMock();
-        $client->expects($this->any())->method('setMethod')->with(Request::METHOD_GET)->willReturnSelf();
-        $client->expects($this->any())->method('setUri')->with('entity')->willReturnSelf();
         $client->expects($this->any())->method('send')->willReturn($this->getResponse('somethingJson', json_encode($data), 500));
 
         $this->object->setUriMask('entity')->setClient($client)->send($model);
+    }
+    
+        
+    public function testMethod(){
+        $this->assertEquals(Request::METHOD_GET, $this->object->getMethod());
     }
 }

--- a/tests/src/Orm/Events/Persistence/Http/Methods/PostTest.php
+++ b/tests/src/Orm/Events/Persistence/Http/Methods/PostTest.php
@@ -61,9 +61,7 @@ class PostTest extends TestCase
         $response = $this->getResponse('something/json', \json_encode($data));
 
         $client = $this->getMockBuilder(Client::class)->getMock();
-        $client->expects($this->once())->method('setUri')->with('bobsYourUncle')->willReturnSelf();
         $client->expects($this->once())->method('setParameterPost')->with($data)->willReturnSelf();
-        $client->expects($this->once())->method('setMethod')->with(Request::METHOD_POST)->willReturnSelf();
         $client->expects($this->once())->method('send')->willReturn($response);
 
         $model = $this->getModel(0, $data, $this->getIsHttp('id', 'bobsYourAunt', 'bobsYourUncle'));
@@ -81,13 +79,15 @@ class PostTest extends TestCase
         $response = $this->getResponse('something/json', \json_encode($data), 500);
 
         $client = $this->getMockBuilder(Client::class)->getMock();
-        $client->expects($this->once())->method('setUri')->with('bobsYourUncle')->willReturnSelf();
         $client->expects($this->once())->method('setParameterPost')->with($data)->willReturnSelf();
-        $client->expects($this->once())->method('setMethod')->with(Request::METHOD_POST)->willReturnSelf();
         $client->expects($this->once())->method('send')->willReturn($response);
 
         $model = $this->getModel(0, $data, $this->getIsHttp('id', 'bobsYourAunt', 'bobsYourUncle'));
 
         $this->object->setUriMask('bobsYourUncle')->setClient($client)->send($model);
+    }
+        
+    public function testMethod(){
+        $this->assertEquals(Request::METHOD_POST, $this->object->getMethod());
     }
 }

--- a/tests/src/Orm/Events/Persistence/Http/Methods/PutTest.php
+++ b/tests/src/Orm/Events/Persistence/Http/Methods/PutTest.php
@@ -65,9 +65,7 @@ class PutTest extends TestCase
         $response = $this->getResponse('something/json', \json_encode($data));
 
         $client = $this->getMockBuilder(Client::class)->getMock();
-        $client->expects($this->once())->method('setUri')->with('bobsYourAunt')->willReturnSelf();
         $client->expects($this->once())->method('setParameterPost')->with($data)->willReturnSelf();
-        $client->expects($this->once())->method('setMethod')->with(Request::METHOD_PUT)->willReturnSelf();
         $client->expects($this->once())->method('send')->willReturn($response);
 
         $model = $this->getModel(0, $data, $this->getIsHttp('id', 'bobsYourAunt', 'bobsYourUncle'));
@@ -87,14 +85,16 @@ class PutTest extends TestCase
         $response = $this->getResponse('something/json', \json_encode($data), 500);
 
         $client = $this->getMockBuilder(Client::class)->getMock();
-        $client->expects($this->once())->method('setUri')->with('bobsYourAunt')->willReturnSelf();
         $client->expects($this->once())->method('setParameterPost')->with($data)->willReturnSelf();
-        $client->expects($this->once())->method('setMethod')->with(Request::METHOD_PUT)->willReturnSelf();
         $client->expects($this->once())->method('send')->willReturn($response);
 
         $model = $this->getModel(0, $data, $this->getIsHttp('id', 'bobsYourAunt', 'bobsYourUncle'));
         $model->expects($this->exactly(0))->method('setData');
 
         $this->object->setUriMask('bobsYourAunt')->setClient($client)->send($model);
+    }
+
+    public function testMethod(){
+        $this->assertEquals(Request::METHOD_PUT, $this->object->getMethod());
     }
 }


### PR DESCRIPTION
task: #139

#### Fixes
Fixes #139 

#### Changes proposed in this pull request:
- Removed header logic in the HTTP persistence events in favor of a client visitor that allows full access to the client object. This will allow for more access to varying types of HTTP options.

#### Checklist
*place an x confirming all items have been verified*
- [x]  Unit tests coverage exceeds or maintains current levels (run command: ```composer test```)
- [x]  Code Sniffer has reported zero issues (run command: ```composer inspect```)
- [x]  Documentation is thorough and rich in content
