### PR TITLE
Add visitor interface to data providers

### DIFF
--- a/tests/src/Orm/Events/DataProvider/DataProviderEventTest.php
+++ b/tests/src/Orm/Events/DataProvider/DataProviderEventTest.php
@@ -24,10 +24,12 @@
  */
 namespace DSchoenbauer\Orm\Events\DataProvider;
 
+use DSchoenbauer\Orm\CrudModel;
 use DSchoenbauer\Orm\DataProvider\DataProviderInterface;
 use DSchoenbauer\Orm\Entity\EntityInterface;
 use DSchoenbauer\Orm\Model;
 use DSchoenbauer\Orm\ModelInterface;
+use DSchoenbauer\Tests\Orm\Events\DataProvider\MockDataProviderVisitor;
 use PHPUnit\Framework\TestCase;
 use Zend\EventManager\EventInterface;
 
@@ -44,7 +46,7 @@ class DataProviderEventTest extends TestCase
     protected function setUp()
     {
         $this->dataProviderMock = $this->getMockBuilder(DataProviderInterface::class)->disableOriginalConstructor()->getMock();
-        $this->object = new DataProviderEvent([], $this->dataProviderMock);
+        $this->object = new DataProviderEvent(['someEvent'], $this->dataProviderMock);
     }
 
     public function testOnExecuteModelFail()
@@ -52,29 +54,47 @@ class DataProviderEventTest extends TestCase
         $event = $this->getMockBuilder(EventInterface::class)->getMock();
         $this->assertFalse($this->object->onExecute($event));
     }
-    
+
     public function testOnExecuteEntityFail()
     {
         $model = $this->getMockBuilder(ModelInterface::class)->getMock();
-        
+
         $event = $this->getMockBuilder(EventInterface::class)->getMock();
         $event->expects($this->once())->method('getTarget')->willReturn($model);
-        
+
         $this->assertFalse($this->object->onExecute($event));
     }
-    
+
+    public function testOnExecuteVisitModel()
+    {
+        $mockEntity = $this->getMockBuilder(EntityInterface::class)->getMock();
+        $model = new CrudModel($mockEntity);
+
+        $data = ['test' => true];
+        $attr = ['a' => 'b', 'c' => 'd', 'e' => 'f'];
+
+        $this->object->setDataProvider(new MockDataProviderVisitor($data, $attr));
+        $model->accept($this->object);
+        $model->getEventManager()->trigger('someEvent', $model);
+        
+        $this->assertEquals($data, $model->getData());
+        $this->assertEquals('b',$model->getAttributes()->get('a'));
+        $this->assertEquals('d',$model->getAttributes()->get('c'));
+        $this->assertEquals('f',$model->getAttributes()->get('e'));
+    }
+
     public function testOnExecuteSuccess()
     {
         $data = ['some' => 'test'];
         $this->dataProviderMock->expects($this->once())->method('getData')->willReturn($data);
-            
+
         $model = $this->getMockBuilder(Model::class)->disableOriginalConstructor()->getMock();
         $model->expects($this->once())->method('getEntity')->willReturn($this->getMockBuilder(EntityInterface::class)->getMock());
         $model->expects($this->once())->method('setData')->with($data);
-        
+
         $event = $this->getMockBuilder(EventInterface::class)->getMock();
         $event->expects($this->once())->method('getTarget')->willReturn($model);
-        
+
         $this->assertTrue($this->object->onExecute($event));
     }
 

--- a/tests/src/Orm/Events/DataProvider/MockDataProviderVisitor.php
+++ b/tests/src/Orm/Events/DataProvider/MockDataProviderVisitor.php
@@ -22,55 +22,53 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-namespace DSchoenbauer\Orm\Events\DataProvider;
+namespace DSchoenbauer\Tests\Orm\Events\DataProvider;
 
 use DSchoenbauer\Orm\DataProvider\DataProviderInterface;
-use DSchoenbauer\Orm\Entity\EntityInterface;
-use DSchoenbauer\Orm\Enum\EventPriorities as EventPriority;
-use DSchoenbauer\Orm\Events\AbstractEvent;
+use DSchoenbauer\Orm\ModelInterface;
 use DSchoenbauer\Orm\VisitorInterface;
-use Zend\EventManager\EventInterface;
 
 /**
- * Description of DataProviderEvent
- *
  * @author David Schoenbauer
  */
-class DataProviderEvent extends AbstractEvent
+class MockDataProviderVisitor implements DataProviderInterface, VisitorInterface
 {
+    private $data = [];
+    private $attributes = [];
 
-    private $dataProvider;
-
-    public function __construct(array $events, DataProviderInterface $dataProvider, $priority = EventPriority::ON_TIME)
+    public function __construct($data, $attributes)
     {
-        parent::__construct($events, $priority);
-        $this->setDataProvider($dataProvider);
+        $this->setData($data)->setAttributes($attributes);
+        
     }
 
-    public function onExecute(EventInterface $event)
+    public function visitModel(ModelInterface $model)
     {
-        $model = $event->getTarget();
-        if (!$this->validateModel($model, EntityInterface::class)) {
-            return false;
+        foreach ($this->getAttributes() as $key => $value) {
+            $model->getAttributes()->set($key, $value);
         }
-        if ($this->getDataProvider() instanceof VisitorInterface) {
-            $model->accept($this->getDataProvider());
-        }
-        $model->setData($this->getDataProvider()->getData());
-        return true;
     }
 
-    /**
-     * @return DataProviderInterface
-     */
-    public function getDataProvider()
+    public function getData()
     {
-        return $this->dataProvider;
+        return $this->data;
     }
 
-    public function setDataProvider(DataProviderInterface $dataProvider)
+    public function setData($data)
     {
-        $this->dataProvider = $dataProvider;
+        $this->data = $data;
         return $this;
     }
+
+    public function getAttributes()
+    {
+        return $this->attributes;
+    }
+
+    public function setAttributes(array $attributes)
+    {
+        $this->attributes = $attributes;
+        return $this;
+    }
+
 }


### PR DESCRIPTION
need a better way to communicate from the model to the data provider.

task: #146

#### Fixes
Fixes #146 

#### Changes proposed in this pull request:
- Add the visitor interface to allow the data-provider access to the model to retrieve or set data
-
-
-
#### Checklist
*place an x confirming all items have been verified*
- [x]  Unit tests coverage exceeds or maintains current levels (run command: ```composer test```)
- [x]  Code Sniffer has reported zero issues (run command: ```composer inspect```)
- [x]  Documentation is thorough and rich in content
