### PR TITLE
Update syntax to meet standards

### DIFF
--- a/src/Orm/DataProvider/EntityDataProvider.php
+++ b/src/Orm/DataProvider/EntityDataProvider.php
@@ -45,7 +45,7 @@ class EntityDataProvider implements DataProviderInterface
         $this->getSelect()
             ->setTable($this->getEntity()->getTable())
             ->setFields(array_merge([$this->getEntity()->getIdField() . ' idx'], $this->getEntity()->getAllFields()))
-            ->setFetchStyle(\PDO::FETCH_ASSOC || \PDO::FETCH_UNIQUE)
+            ->setFetchStyle(\PDO::FETCH_ASSOC | \PDO::FETCH_UNIQUE)
             ->setFetchFlat(false);
         return $this->getSelect()->execute($this->getAdapter());
     }

--- a/tests/src/Orm/DataProvider/EntityDataProviderTest.php
+++ b/tests/src/Orm/DataProvider/EntityDataProviderTest.php
@@ -83,7 +83,7 @@ class EntityDataProviderTest extends TestCase
         $select = $this->getMockBuilder(Select::class)->disableOriginalConstructor()->getMock();
         $select->expects($this->atLeast(1))->method('setTable')->with($table)->willReturnSelf();
         $select->expects($this->atLeast(1))->method('setFields')->with(['id idx', 'id', 'test'])->willReturnSelf();
-        $select->expects($this->atLeast(1))->method('setFetchStyle')->with(\PDO::FETCH_ASSOC || \PDO::FETCH_UNIQUE)->willReturnSelf();
+        $select->expects($this->atLeast(1))->method('setFetchStyle')->with(\PDO::FETCH_ASSOC | \PDO::FETCH_UNIQUE)->willReturnSelf();
         $select->expects($this->atLeast(1))->method('setFetchFlat')->with(false)->willReturnSelf();
         $select->expects($this->atLeast(1))->method('execute')->with($adapter)->willReturn($result);
 


### PR DESCRIPTION
task: #150

#### Fixes
Fixes #150 

#### Changes proposed in this pull request:
- Removed extra pipe char (|) from Orm/DataProvider/EntityDataProvider

#### Checklist
*place an x confirming all items have been verified*
- [X]  Unit tests coverage exceeds or maintains current levels (run command: ```composer test```)
- [X]  Code Sniffer has reported zero issues (run command: ```composer inspect```)
- [X]  Documentation is thorough and rich in content
