### PR TITLE
Add an event to throw an exception

### DIFF
--- a/src/Orm/Enum/EventParameters.php
+++ b/src/Orm/Enum/EventParameters.php
@@ -1,0 +1,35 @@
+<?php
+/*
+ * The MIT License
+ *
+ * Copyright 2018 David Schoenbauer.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+namespace DSchoenbauer\Orm\Enum;
+
+/**
+ * A list of possible keys for event parameters
+ *
+ * @author David Schoenbauer
+ */
+class EventParameters
+{
+    const EXCEPTION = "exception";
+}

--- a/src/Orm/Events/Logger/ThrowExceptionEvent.php
+++ b/src/Orm/Events/Logger/ThrowExceptionEvent.php
@@ -1,0 +1,69 @@
+<?php
+/*
+ * The MIT License
+ *
+ * Copyright 2018 David Schoenbauer.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+namespace DSchoenbauer\Orm\Events\Logger;
+
+use DSchoenbauer\Orm\Enum\EventParameters;
+use DSchoenbauer\Orm\Enum\EventPriorities;
+use DSchoenbauer\Orm\Events\AbstractEvent;
+use Exception;
+use Zend\EventManager\EventInterface;
+
+/**
+ * Description of ThrowExceptionEvent
+ *
+ * @author David Schoenbauer
+ */
+class ThrowExceptionEvent extends AbstractEvent
+{
+
+    const NO_EXCEPTION_MESSAGE = "Exception expected to be thrown but no exception provided";
+
+    private $alwaysThrowException = false;
+    
+    public function __construct(array $events = [], $alwaysThrowException = false, $priority = EventPriorities::ON_TIME)
+    {
+        $this->setAlwaysThrowException($alwaysThrowException);
+        parent::__construct($events, $priority);
+    }
+
+    public function onExecute(EventInterface $event)
+    {
+        if (!$event->getParam(EventParameters::EXCEPTION) instanceof Exception) {
+            throw new Exception(static::NO_EXCEPTION_MESSAGE);
+        }
+        throw $event->getParam(EventParameters::EXCEPTION);
+    }
+
+    public function getAlwaysThrowException()
+    {
+        return $this->alwaysThrowException;
+    }
+
+    public function setAlwaysThrowException($alwaysThrowException = true)
+    {
+        $this->alwaysThrowException = $alwaysThrowException;
+        return $this;
+    }
+}

--- a/tests/src/Orm/Events/Logger/ThrowExceptionEventTest.php
+++ b/tests/src/Orm/Events/Logger/ThrowExceptionEventTest.php
@@ -1,0 +1,81 @@
+<?php
+/*
+ * The MIT License
+ *
+ * Copyright 2018 David Schoenbauer.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+namespace DSchoenbauer\Orm\Events\Logger;
+
+use Exception;
+use PHPUnit\Framework\TestCase;
+use Zend\EventManager\EventInterface;
+
+/**
+ * Description of ThrowExceptionEventTest
+ *
+ * @author David Schoenbauer
+ */
+class ThrowExceptionEventTest extends TestCase
+{
+    private $object;
+    
+    protected function setUp()
+    {
+        $this->object = new ThrowExceptionEvent();
+    }
+    
+    function testOnExecuteGoodParameter(){
+        $event = $this->getMockBuilder(EventInterface::class)->getMock();
+        $exception = new Exception('Test');
+        $event->expects($this->any())->method('getParam')->willReturn($exception);
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Test');
+        $this->object->onExecute($event);
+    }
+    
+    function testOnExecuteBadParameter(){
+        $event = $this->getMockBuilder(EventInterface::class)->getMock();
+        $exception = new Exception('Test');
+        $this->expectException(Exception::class);
+        $event->expects($this->any())->method('getParam')->willReturn(new \stdClass());
+        $this->expectExceptionMessage(ThrowExceptionEvent::NO_EXCEPTION_MESSAGE);
+        $this->object->onExecute($event);
+    }
+    
+    function testOnExecuteNoParameter(){
+        $event = $this->getMockBuilder(EventInterface::class)->getMock();
+        $exception = new Exception('Test');
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage(ThrowExceptionEvent::NO_EXCEPTION_MESSAGE);
+        $this->object->onExecute($event);
+    }
+    
+    function testAlwaysThrowException(){
+        $this->assertFalse($this->object->getAlwaysThrowException());
+        $this->assertTrue($this->object->setAlwaysThrowException()->getAlwaysThrowException());
+        $this->assertFalse($this->object->setAlwaysThrowException(false)->getAlwaysThrowException());
+    }
+    
+    function testAlwaysThrowExceptionContructor(){
+        $this->object = new ThrowExceptionEvent([], true);
+        $this->assertTrue($this->object->getAlwaysThrowException());
+    }
+}


### PR DESCRIPTION
task: #170

#### Fixes
Fixes #170

#### Changes proposed in this pull request:
- Add a new event to throw an exception.

#### Checklist
*place an x confirming all items have been verified*
- [x]  Unit tests coverage exceeds or maintains current levels (run command: ```composer test```)
- [x]  Code Sniffer has reported zero issues (run command: ```composer inspect```)
- [x]  Documentation is thorough and rich in content
